### PR TITLE
fix: refresh the active account's usage from live credentials

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -119,7 +119,14 @@ func RefreshActive(email string) error {
 // refreshOne reads the account's stored credentials, refreshes the
 // access token if it is expired or near expiry, and queries the usage API.
 //
-// Token refresh priority:
+// Token source priority:
+//  0. If this account is the one Claude Code is currently running, use
+//     the live credentials file instead of the per-account backup. The
+//     backup is only rewritten on switch, so for the active account it
+//     can be hours stale; Claude Code keeps the live file continuously
+//     refreshed. A stale backup access token is routinely rejected by
+//     the usage API once Claude Code has rotated the refresh token,
+//     which previously left the active account's cache entry frozen.
 //  1. If IsTokenExpired: call RefreshBlob (standard OAuth refresh_token flow)
 //     and update the backup so the next call is already fresh.
 //  2. If the API still returns 401 (e.g. the refresh token itself expired):
@@ -129,6 +136,16 @@ func refreshOne(slot int, email, orgUUID string) (usage.AccountUsage, error) {
 	blob, err := creds.ReadBackup(slot, email)
 	if err != nil {
 		return usage.AccountUsage{}, err
+	}
+
+	// Prefer the live credentials for whichever account is currently
+	// active — see step 0 above. The backup still serves as the source
+	// for every inactive account, and as the fallback below if the live
+	// token is itself rejected.
+	usingLive := false
+	if liveBlob, ok := liveBlobFor(email, orgUUID); ok {
+		blob = liveBlob
+		usingLive = true
 	}
 
 	// Proactively refresh before we even try the API if the token is
@@ -157,6 +174,13 @@ func refreshOne(slot int, email, orgUUID string) (usage.AccountUsage, error) {
 	}
 	u, err := usage.Fetch(token)
 	if err == nil {
+		// When the token came from the live file, write it back to the
+		// per-account backup so the backup stops rotting and the next
+		// refresh has a fresh starting point even if Claude Code is not
+		// running.
+		if usingLive {
+			_ = creds.WriteBackup(slot, email, blob)
+		}
 		if _, writeErr := syncLiveIfActive(email, orgUUID, blob); writeErr != nil {
 			return usage.AccountUsage{}, fmt.Errorf("monitor: save active live token: %w", writeErr)
 		}
@@ -194,6 +218,33 @@ func refreshOne(slot int, email, orgUUID string) (usage.AccountUsage, error) {
 	// Best-effort: if this fails we still return the valid usage data.
 	_ = creds.WriteBackup(slot, email, liveBlob)
 	return u2, nil
+}
+
+// liveBlobFor returns the live credential blob when it belongs to the
+// given account — that is, when Claude Code is currently running this
+// account. Identity is confirmed against the oauthAccount block in the
+// Claude Code config (email, and orgUUID when known) so a different
+// account's token can never be returned. The boolean is false, with no
+// error, whenever the account is not the active one or the live file
+// cannot be read; callers fall back to the per-account backup.
+func liveBlobFor(email, orgUUID string) (string, bool) {
+	if email == "" {
+		return "", false
+	}
+	_, parsed, err := claudecfg.ReadOAuthBlock()
+	if err != nil || parsed.EmailAddress != email {
+		return "", false
+	}
+	// When orgUUID is known, also require the org to match so two
+	// accounts sharing an email address are never conflated.
+	if orgUUID != "" && parsed.OrganizationUUID != orgUUID {
+		return "", false
+	}
+	liveBlob, err := creds.ReadLive()
+	if err != nil || liveBlob == "" {
+		return "", false
+	}
+	return liveBlob, true
 }
 
 func syncLiveIfActive(email, orgUUID, blob string) (bool, error) {

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,6 +1,8 @@
 package monitor
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,6 +12,36 @@ import (
 	"github.com/inulute/cux/internal/creds"
 	"github.com/inulute/cux/internal/paths"
 )
+
+// writeClaudeConfig writes a minimal Claude Code config whose
+// oauthAccount block names the given active account.
+func writeClaudeConfig(t *testing.T, dir, email, org string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := `{"oauthAccount":{"emailAddress":"` + email + `","accountUuid":"uuid-x","organizationUuid":"` + org + `"}}`
+	if err := os.WriteFile(filepath.Join(dir, ".claude", ".claude.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// usageServer returns a fake usage API that answers 200 only for the
+// one access token it is told to accept; every other token gets 500,
+// standing in for the way Anthropic rejects a stale access token.
+func usageServer(t *testing.T, acceptToken string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+acceptToken {
+			http.Error(w, "stale token", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":42},"seven_day":{"utilization":50}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
 
 func TestSyncLiveIfActiveWritesOnlyMatchingLiveAccount(t *testing.T) {
 	if runtime.GOOS != "linux" {
@@ -101,5 +133,114 @@ func TestRefreshAllReportsUnreadableUsageCache(t *testing.T) {
 		t.Fatal("RefreshAll should report corrupt usage cache")
 	} else if !strings.Contains(errs[0].Error(), "usage: parse cache") {
 		t.Fatalf("RefreshAll error = %v, want usage cache parse error", errs[0])
+	}
+}
+
+const (
+	staleBlob = `{"claudeAiOauth":{"accessToken":"stale-token","refreshToken":"r"}}`
+	freshBlob = `{"claudeAiOauth":{"accessToken":"fresh-token","refreshToken":"r"}}`
+)
+
+// TestRefreshOnePrefersLiveBlobForActiveAccount is the regression test
+// for the active account never refreshing: its per-account backup is
+// only rewritten on switch, so its access token goes stale and the
+// usage API rejects it. refreshOne must read the freshly-rotated token
+// from the live credentials file for whichever account is active.
+func TestRefreshOnePrefersLiveBlobForActiveAccount(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("live credential file test is Linux-only")
+	}
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, ".local", "share"))
+
+	srv := usageServer(t, "fresh-token")
+	t.Setenv("CUX_USAGE_ENDPOINT", srv.URL)
+
+	// This account is the active one, and only the live file has the
+	// token the API still accepts; the backup is stale.
+	writeClaudeConfig(t, dir, "active@example.com", "org-1")
+	if err := creds.WriteBackup(1, "active@example.com", staleBlob); err != nil {
+		t.Fatal(err)
+	}
+	if err := creds.WriteLive(freshBlob); err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := refreshOne(1, "active@example.com", "org-1")
+	if err != nil {
+		t.Fatalf("refreshOne errored for active account: %v", err)
+	}
+	if u.FiveHour == nil || u.FiveHour.Utilization != 42 {
+		t.Fatalf("refreshOne returned %+v, want five_hour utilization 42", u)
+	}
+	// The stale backup should have been refreshed from the live token.
+	got, err := creds.ReadBackup(1, "active@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != freshBlob {
+		t.Fatalf("backup not refreshed from live token: %s", got)
+	}
+}
+
+// TestRefreshOneUsesBackupForInactiveAccount confirms the live-blob
+// preference is scoped to the active account only: an inactive account
+// must still be refreshed from its own per-account backup, never from
+// the unrelated live credentials.
+func TestRefreshOneUsesBackupForInactiveAccount(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("live credential file test is Linux-only")
+	}
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, ".local", "share"))
+
+	srv := usageServer(t, "fresh-token")
+	t.Setenv("CUX_USAGE_ENDPOINT", srv.URL)
+
+	// A different account is active. The live file holds a token the
+	// API rejects; only the inactive account's own backup is valid.
+	writeClaudeConfig(t, dir, "active@example.com", "org-1")
+	if err := creds.WriteLive(staleBlob); err != nil {
+		t.Fatal(err)
+	}
+	if err := creds.WriteBackup(2, "inactive@example.com", freshBlob); err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := refreshOne(2, "inactive@example.com", "org-2")
+	if err != nil {
+		t.Fatalf("refreshOne errored for inactive account: %v", err)
+	}
+	if u.FiveHour == nil || u.FiveHour.Utilization != 42 {
+		t.Fatalf("refreshOne returned %+v, want five_hour utilization 42", u)
+	}
+}
+
+// TestLiveBlobForMatchesActiveAccountOnly checks the identity guard:
+// the live blob is returned only for the exact active email+org, so a
+// different account's token can never be used.
+func TestLiveBlobForMatchesActiveAccountOnly(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("live credential file test is Linux-only")
+	}
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, ".local", "share"))
+
+	writeClaudeConfig(t, dir, "active@example.com", "org-1")
+	if err := creds.WriteLive(freshBlob); err != nil {
+		t.Fatal(err)
+	}
+
+	if blob, ok := liveBlobFor("active@example.com", "org-1"); !ok || blob != freshBlob {
+		t.Fatalf("liveBlobFor(active, org-1) = %q,%v; want the live blob,true", blob, ok)
+	}
+	if _, ok := liveBlobFor("other@example.com", ""); ok {
+		t.Fatal("liveBlobFor returned a blob for a non-active email")
+	}
+	if _, ok := liveBlobFor("active@example.com", "wrong-org"); ok {
+		t.Fatal("liveBlobFor returned a blob when the org did not match")
 	}
 }


### PR DESCRIPTION
## Problem

`cux usage refresh` (and `RefreshAll`) never updates whichever account is **currently active**. Its usage row in `cux list` stays frozen at whatever it was when the account was last *inactive*.

### Why

`refreshOne` reads each account's token from its per-account backup (`accounts/NN-email/credentials.json`), which cux only rewrites on **switch**. For the active account that backup goes stale within hours. Claude Code, meanwhile, continuously refreshes the *live* `~/.claude/.credentials.json`. Once Claude Code rotates the refresh token, the stale backup access token is rejected by the usage API. Because that rejection is not always a clean `401`, the existing live-credentials fallback (which is gated on `u.TokenExpired`) is skipped, `refreshOne` returns the error, and `RefreshAll` keeps the previous cache entry:

```go
for slot, a := range state.Accounts {
    entry, err := refreshOne(slot, a.Email, a.OrgUUID)
    if err != nil {
        errs = append(errs, ...)
        if entry.TokenExpired { cache[a.CacheKey()] = entry }
        continue   // <- stale entry survives
    }
    cache[a.CacheKey()] = entry
}
```

Net effect: the one account the user is actively burning through is the one whose usage never updates.

## Fix

`refreshOne` now prefers the **live** credentials file for whichever account is active, since Claude Code keeps it fresh. The account is confirmed to be the active one by matching `email` + `orgUUID` against the `oauthAccount` block (`liveBlobFor`), so a different account's token can never be used.

- Inactive accounts are **unchanged** — still refreshed from their own backup.
- The existing `401` → live fallback is retained as a safety net.
- On a successful live-token refresh the per-account backup is rewritten, so it stops rotting.

## Tests

`internal/monitor/monitor_test.go`:

- `TestRefreshOnePrefersLiveBlobForActiveAccount` — regression test: stale backup token, fresh live token, fake usage API rejects the stale one; `refreshOne` must succeed via the live token.
- `TestRefreshOneUsesBackupForInactiveAccount` — an inactive account still refreshes from its own backup, never the unrelated live file.
- `TestLiveBlobForMatchesActiveAccountOnly` — the email+org identity guard.

`go test ./...` passes; `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)