### PR TITLE
fix: key the usage cache per seat, not per organization

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,10 +32,17 @@ type Account struct {
 	LastUsed time.Time `json:"lastUsed,omitempty"`
 }
 
-// CacheKey returns the usage-cache key for this account. When OrgUUID is
-// set it is used as the key so two accounts sharing the same email get
-// independent cache entries. Falls back to email for legacy slots.
+// CacheKey returns the usage-cache key for this account. Usage limits are
+// tracked per seat — one (account, organization) pair — so the key combines
+// both UUIDs: two accounts sharing an email but in different orgs get
+// distinct entries, and so do different accounts inside the same org
+// (keying on OrgUUID alone made those collapse into one entry that every
+// refresh overwrote). Falls back to OrgUUID, then email, for legacy slots
+// recorded before these fields existed.
 func (a Account) CacheKey() string {
+	if a.UUID != "" && a.OrgUUID != "" {
+		return a.UUID + "|" + a.OrgUUID
+	}
 	if a.OrgUUID != "" {
 		return a.OrgUUID
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,31 @@
+package store
+
+import "testing"
+
+func TestCacheKeyDistinguishesSeats(t *testing.T) {
+	// Different accounts inside the same organization must not share a key.
+	a := Account{Email: "a@corp.test", UUID: "uuid-a", OrgUUID: "org-1"}
+	b := Account{Email: "b@corp.test", UUID: "uuid-b", OrgUUID: "org-1"}
+	if a.CacheKey() == b.CacheKey() {
+		t.Errorf("same-org accounts share cache key %q", a.CacheKey())
+	}
+
+	// The same email in two organizations must not share a key either.
+	pro := Account{Email: "me@x.test", UUID: "uuid-me", OrgUUID: "org-personal"}
+	team := Account{Email: "me@x.test", UUID: "uuid-me", OrgUUID: "org-team"}
+	if pro.CacheKey() == team.CacheKey() {
+		t.Errorf("same-email cross-org accounts share cache key %q", pro.CacheKey())
+	}
+}
+
+func TestCacheKeyLegacyFallbacks(t *testing.T) {
+	// Pre-UUID slots keep the org key; pre-org slots keep the email key.
+	orgOnly := Account{Email: "a@x.test", OrgUUID: "org-1"}
+	if got := orgOnly.CacheKey(); got != "org-1" {
+		t.Errorf("org-only account: got %q, want %q", got, "org-1")
+	}
+	emailOnly := Account{Email: "a@x.test"}
+	if got := emailOnly.CacheKey(); got != "a@x.test" {
+		t.Errorf("email-only account: got %q, want %q", got, "a@x.test")
+	}
+}

--- a/internal/switcher/switcher.go
+++ b/internal/switcher/switcher.go
@@ -277,14 +277,18 @@ func CurrentLiveEmail() (string, error) {
 }
 
 // CurrentLiveCacheKey returns the usage-cache key for the currently active
-// account. When the account has an organizationUuid that is used; otherwise
-// the email is returned for backward compatibility.
+// account, derived the same way store.Account.CacheKey does so live and
+// managed lookups always agree.
 func CurrentLiveCacheKey() (string, error) {
 	_, parsed, err := claudecfg.ReadOAuthBlock()
 	if err != nil {
 		return "", err
 	}
-	acct := store.Account{Email: parsed.EmailAddress, OrgUUID: parsed.OrganizationUUID}
+	acct := store.Account{
+		Email:   parsed.EmailAddress,
+		UUID:    parsed.AccountUUID,
+		OrgUUID: parsed.OrganizationUUID,
+	}
 	return acct.CacheKey(), nil
 }
 


### PR DESCRIPTION
Fixes #8.

## Problem

Keying the usage cache by `organizationUuid` (v0.2.10) fixed same-email accounts in different orgs, but broke the inverse: multiple accounts inside the **same organization** all collapse into one cache entry that every refresh overwrites. Usage limits are actually tracked per seat — one (account, organization) pair — which the usage API confirms: four accounts in one org report 100% / 14% / 5% / 2% five-hour utilization individually, while `cux list` showed the same number for all of them. That corrupts auto-switch decisions both ways: cux may swap to an account that is actually at 100% (instant rate limit), or refuse to swap because every candidate appears exhausted when only one is.

## Change

- `store.Account.CacheKey()` now returns `UUID + "|" + OrgUUID` when both are set. Fallbacks preserved for legacy slots: `OrgUUID` alone, then email. The same-email/different-orgs case from #1 stays separated (same UUID, different OrgUUID → distinct keys).
- `switcher.CurrentLiveCacheKey()` now fills `UUID` from the parsed OAuth block and derives the key through `store.Account.CacheKey`, so live and managed lookups always agree.
- Added unit tests covering both collision cases and both legacy fallbacks (first tests for `internal/store`).

Existing cache entries under the old key are simply superseded on the next refresh — until then lookups miss and rows show "—", same as a fresh install.

All read/write sites already go through `Account.CacheKey()` / `CurrentLiveCacheKey()`, so no other call sites needed changes.

## Tested on macOS 15 (arm64)

- `go vet ./...` clean; `go test ./internal/store ./internal/strategy ./internal/wrapper ./internal/monitor` pass
- With the 4-account setup from #8: after `usage refresh`, `cux list` shows four distinct utilization rows matching per-token API responses