### PR TITLE
fix: preserve claude flags when relaunching after an account swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ If the answer is `4729`, swap-and-resume is working.
              │     ask claude to exit cleanly       │
              │     swap creds (transactional)       │
              │     append history.Entry             │
-             │     relaunch claude --resume <id>    │
-             │       [optional auto_message]        │
+             │     relaunch claude <orig. flags>    │
+             │       --resume <id> [auto_message]   │
              └──────────────────────────────────────┘
 ```
 

--- a/internal/wrapper/relaunch_test.go
+++ b/internal/wrapper/relaunch_test.go
@@ -1,0 +1,72 @@
+package wrapper
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRelaunchFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "keeps boolean flag, drops bare resume",
+			in:   []string{"--dangerously-skip-permissions", "--resume"},
+			want: []string{"--dangerously-skip-permissions"},
+		},
+		{
+			name: "drops resume with session id value",
+			in:   []string{"-r", "abc-123", "--verbose"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "keeps value flags, drops positional prompt",
+			in:   []string{"--model", "opus", "fix the bug"},
+			want: []string{"--model", "opus"},
+		},
+		{
+			name: "equals forms",
+			in:   []string{"--resume=abc", "--model=opus"},
+			want: []string{"--model=opus"},
+		},
+		{
+			name: "drops continue and session-id",
+			in:   []string{"--session-id", "uuid-1", "-c"},
+			want: []string{},
+		},
+		{
+			name: "drops fork-session without eating next flag",
+			in:   []string{"--fork-session", "--verbose"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "bare resume followed by flag eats nothing",
+			in:   []string{"--resume", "--dangerously-skip-permissions"},
+			want: []string{"--dangerously-skip-permissions"},
+		},
+		{
+			name: "leading positional prompt dropped",
+			in:   []string{"explain this repo", "--verbose"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "everything after separator dropped",
+			in:   []string{"--verbose", "--", "--resume"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "empty argv",
+			in:   []string{},
+			want: []string{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := relaunchFlags(c.in); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("relaunchFlags(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -231,7 +231,7 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 				fmt.Fprintf(w, "cux: %s → %s (%s), resuming…\n", from.Email, to.Email, p.reason)
 			}
 			waitForTranscript(cwd, sessionID, transcriptWaitTimeout)
-			currentArgv = []string{"--resume", sessionID}
+			currentArgv = append(relaunchFlags(argv), "--resume", sessionID)
 			if p.resumeMessage != "" {
 				// Write a one-shot flag so the UserPromptSubmit hook skips the
 				// threshold check for this replayed prompt. Without this, if the
@@ -871,6 +871,76 @@ func accountHasSwitchCapacity(cache usage.Cache, cacheKey string, cfg *config.Co
 		cap5 = 90
 	}
 	return u.FiveHour == nil || u.FiveHour.Utilization < float64(cap5)
+}
+
+// sessionFlags are claude's session-selection arguments. The wrapper
+// substitutes its own `--resume <id>` on relaunch, so whatever the user
+// passed to pick a session must not survive alongside it.
+var sessionFlags = map[string]bool{
+	"--resume": true, "-r": true,
+	"--continue": true, "-c": true,
+	"--session-id":   true,
+	"--fork-session": true,
+}
+
+// sessionValueFlags are the session flags that may consume the next
+// token as their value (`--resume <id>`, `--session-id <uuid>`).
+var sessionValueFlags = map[string]bool{
+	"--resume": true, "-r": true,
+	"--session-id": true,
+}
+
+// claudeBoolFlags are claude flags known to never take a value, so a bare
+// token right after one of them is a positional prompt rather than the
+// flag's value. The list doesn't need to be exhaustive: an unknown
+// boolean flag just means a trailing prompt is kept as its "value" and
+// replayed into the resumed session — mildly redundant, never fatal.
+var claudeBoolFlags = map[string]bool{
+	"--dangerously-skip-permissions": true,
+	"--print":                        true,
+	"-p":                             true,
+	"--verbose":                      true,
+	"--ide":                          true,
+	"--strict-mcp-config":            true,
+}
+
+// relaunchFlags returns the user's original claude arguments minus
+// session selection and minus positional prompts, so a post-swap
+// relaunch keeps flags like --dangerously-skip-permissions or --model
+// while the wrapper controls which session is resumed. Positional
+// prompts are dropped because a resumable session (hadTurns) already
+// has them in its transcript; replaying one would duplicate the turn.
+func relaunchFlags(argv []string) []string {
+	out := []string{}
+	expectValue := false
+	for i := 0; i < len(argv); i++ {
+		tok := argv[i]
+		if tok == "--" {
+			break // everything after the separator is positional
+		}
+		isFlag := len(tok) > 1 && tok[0] == '-'
+		if !isFlag {
+			if expectValue {
+				out = append(out, tok)
+				expectValue = false
+			}
+			continue
+		}
+		expectValue = false
+		name, _, hasEq := strings.Cut(tok, "=")
+		if sessionFlags[name] {
+			if !hasEq && sessionValueFlags[name] &&
+				i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "-") {
+				i++ // skip the flag's session-id value too
+			}
+			continue
+		}
+		out = append(out, tok)
+		if !hasEq && !claudeBoolFlags[name] {
+			expectValue = true
+		}
+	}
+	return out
 }
 
 func isResumeArgv(argv []string) bool {


### PR DESCRIPTION
Fixes #10.

## Problem

After a swap the wrapper relaunched claude with only `[--resume <id>, <message>]`, silently dropping every flag from the original invocation — `--dangerously-skip-permissions` sessions come back from their first auto-swap with permission prompts re-enabled, `--model`/`--mcp-config`/`--allowedTools` are lost the same way.

## Change

Rebuild the relaunch argv from the original one via a new `relaunchFlags` helper:

- **keep** flags and their values (both `--flag value` and `--flag=value` forms)
- **strip** session selection (`--resume`/`-r` incl. optional session-id value, `--continue`/`-c`, `--session-id` + value, `--fork-session`) — the wrapper substitutes its own `--resume <id>`
- **strip** positional prompts — a resumable session (`hadTurns`) already has them in its transcript; replaying one would duplicate the turn (and would collide with the auto-message positional)

Positionals are told apart from flag values with a small table of known boolean flags. It deliberately doesn't need to be exhaustive — the fail-modes degrade gracefully:

- unknown **value** flag → next token treated as its value and kept (correct)
- unknown **boolean** flag → a trailing prompt is kept as its "value" and replayed into the resumed session (mildly redundant, never fatal)

The no-resume branch (fresh start, `hadTurns == false`) keeps the original argv untouched, as before.

## Tested

- `go vet ./...` clean, `gofmt` clean on touched files
- New table-driven test `TestRelaunchFlags` (10 cases: bare `--resume`, `-r <id>`, `=` forms, positional prompts leading/trailing, `--` separator, value flags, empty argv)
- Full `./internal/wrapper` suite passes

Note: on macOS, running the wrapper/hooks test suites writes to the real `~/.cux` — see #7.