### PR TITLE
feat: wait for the earliest reset when every account is exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ cux config set update_check.enabled true            # opt in to update checks
 | `auto_switch_on_rate_limit`   | `true`         | Master toggle for swap on rate-limit hook |
 | `auto_resume`                 | `true`         | Pass `--resume <id>` to the relaunched claude |
 | `auto_message`                | `Go continue.` | First user turn after auto-swap; `""` = silent |
+| `wait_for_reset`              | `true`         | When every account is exhausted, sleep until the earliest reset and resume |
 | `update_check.enabled`        | `false`        | Check GitHub for newer cux releases on startup |
 | `update_check.cadence_hours`  | `6`            | Minimum hours between update checks (cached locally) |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	AutoSwitchOnRateLimit bool              `json:"auto_switch_on_rate_limit"`
 	AutoResume            bool              `json:"auto_resume"`
 	AutoMessage           string            `json:"auto_message"`
+	WaitForReset          bool              `json:"wait_for_reset"`
 	Notify                bool              `json:"notify"`
 	PollIntervalSeconds   int               `json:"poll_interval_seconds"`
 	UpdateCheck           UpdateCheckConfig `json:"update_check"`
@@ -87,6 +88,7 @@ func Defaults() Config {
 		AutoSwitchOnRateLimit: true,
 		AutoResume:            true,
 		AutoMessage:           "Go continue.",
+		WaitForReset:          true,
 		Notify:                true,
 		PollIntervalSeconds:   60,
 		UpdateCheck:           UpdateCheckConfig{Enabled: true, CadenceHours: 6},
@@ -204,6 +206,12 @@ func Set(c Config, key, value string) (Config, error) {
 		} else {
 			c.AutoMessage = value
 		}
+	case "wait_for_reset":
+		b, err := parseBool(value)
+		if err != nil {
+			return c, err
+		}
+		c.WaitForReset = b
 	case "notify":
 		b, err := parseBool(value)
 		if err != nil {
@@ -297,6 +305,11 @@ func Keys(c Config) []KeyInfo {
 			Key: "auto_message", Default: "Go continue.",
 			Description: `first user turn after auto-swap; set to "" for silent resume`,
 			Current:     c.AutoMessage,
+		},
+		{
+			Key: "wait_for_reset", Default: "true",
+			Description: "when every account is exhausted, sleep until the earliest reset and resume",
+			Current:     strconv.FormatBool(c.WaitForReset),
 		},
 		{
 			Key: "notify", Default: "true",

--- a/internal/wrapper/availability_test.go
+++ b/internal/wrapper/availability_test.go
@@ -1,0 +1,82 @@
+package wrapper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/inulute/cux/internal/store"
+	"github.com/inulute/cux/internal/usage"
+)
+
+func win(util float64, resetsAt *time.Time) *usage.Window {
+	return &usage.Window{Utilization: util, ResetsAt: resetsAt}
+}
+
+func TestNextAvailability(t *testing.T) {
+	now := time.Date(2026, 7, 12, 3, 0, 0, 0, time.UTC)
+	in1h := now.Add(1 * time.Hour)
+	in2h := now.Add(2 * time.Hour)
+	in3d := now.Add(72 * time.Hour)
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+
+	accounts := map[int]store.Account{
+		1: {Slot: 1, Email: "a@x.test"},
+		2: {Slot: 2, Email: "b@x.test"},
+	}
+
+	t.Run("picks the earliest 5h reset", func(t *testing.T) {
+		cache := usage.Cache{
+			"a@x.test": {FiveHour: win(100, &in2h), SevenDay: win(50, &in3d)},
+			"b@x.test": {FiveHour: win(100, &in1h), SevenDay: win(40, &in3d)},
+		}
+		at, email, ok := nextAvailability(accounts, cache, th, now)
+		if !ok || email != "b@x.test" || !at.Equal(in1h) {
+			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, in1h, "b@x.test")
+		}
+	})
+
+	t.Run("capped 7d window binds over an earlier 5h reset", func(t *testing.T) {
+		cache := usage.Cache{
+			// a: 5h resets first, but its 7d window is also full until in3d.
+			"a@x.test": {FiveHour: win(100, &in1h), SevenDay: win(100, &in3d)},
+			"b@x.test": {FiveHour: win(100, &in2h), SevenDay: win(40, &in3d)},
+		}
+		at, email, ok := nextAvailability(accounts, cache, th, now)
+		if !ok || email != "b@x.test" || !at.Equal(in2h) {
+			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, in2h, "b@x.test")
+		}
+	})
+
+	t.Run("skips windows missing reset stamps and expired tokens", func(t *testing.T) {
+		cache := usage.Cache{
+			"a@x.test": {FiveHour: win(100, nil)},
+			"b@x.test": {FiveHour: win(100, &in1h), TokenExpired: true},
+		}
+		if _, _, ok := nextAvailability(accounts, cache, th, now); ok {
+			t.Error("expected ok=false when no account has a usable reset time")
+		}
+	})
+
+	t.Run("account under threshold is ready now", func(t *testing.T) {
+		cache := usage.Cache{
+			"a@x.test": {FiveHour: win(100, &in2h)},
+			"b@x.test": {FiveHour: win(30, &in1h)},
+		}
+		at, email, ok := nextAvailability(accounts, cache, th, now)
+		if !ok || email != "b@x.test" || !at.Equal(now) {
+			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, now, "b@x.test")
+		}
+	})
+
+	t.Run("respects lowered thresholds", func(t *testing.T) {
+		lowered := usage.Thresholds{FiveHour: 90, SevenDay: 100}
+		cache := usage.Cache{
+			"a@x.test": {FiveHour: win(95, &in1h)},
+			"b@x.test": {FiveHour: win(92, &in2h)},
+		}
+		at, email, ok := nextAvailability(accounts, cache, lowered, now)
+		if !ok || email != "a@x.test" || !at.Equal(in1h) {
+			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, in1h, "a@x.test")
+		}
+	})
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -167,6 +167,10 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 				target, err = resolveTarget(p.explicitTarget, p.trigger, &cfg)
 			}
 		}
+		if err != nil && cfg.WaitForReset && p.explicitTarget == "" &&
+			(p.trigger == history.TriggerRateLimit || p.trigger == history.TriggerThreshold) {
+			target, err = waitForReset(p.trigger, &cfg, w)
+		}
 		if err != nil {
 			fmt.Fprintf(w, "cux: %v — staying on current account\n", err)
 			return exitCode, nil
@@ -647,6 +651,96 @@ func isActiveHardLimited() bool {
 	}
 	u, ok := cachedUsage(cache, cacheKey, email)
 	return ok && isHardLimitUsage(u)
+}
+
+// waitForReset blocks until the earliest moment a managed account
+// becomes usable again, refreshes usage, and retries target resolution.
+// Reached only when every account is exhausted — the alternative was
+// giving up and stranding an unattended session until a human returns.
+// A few attempts guard against clock skew between the local machine
+// and the API's reset stamps; each retry waits for the next reset, so
+// even the fallback path never spins.
+const (
+	waitForResetAttempts = 4
+	// resetSlack pads each sleep so we wake after the API-side window
+	// has actually rolled over, not in the same second it should.
+	resetSlack = 90 * time.Second
+)
+
+func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (string, error) {
+	for attempt := 0; attempt < waitForResetAttempts; attempt++ {
+		state, err := store.Load()
+		if err != nil {
+			return "", err
+		}
+		cache, _ := usage.LoadCache()
+		readyAt, email, ok := nextAvailability(state.Accounts, cache, cfg.Thresholds, time.Now())
+		if !ok {
+			return "", errors.New("all accounts exhausted and no reset time is known")
+		}
+		d := time.Until(readyAt) + resetSlack
+		if d < resetSlack {
+			d = resetSlack
+		}
+		fmt.Fprintf(w, "cux: all accounts exhausted — waiting %s for %s to reset…\n",
+			shortDuration(d), email)
+		time.Sleep(d)
+		_, _ = monitor.RefreshAll()
+		if target, err := resolveTarget("", trigger, cfg); err == nil {
+			return target, nil
+		}
+	}
+	return "", errors.New("accounts still exhausted after waiting for resets")
+}
+
+// nextAvailability returns the earliest instant any account becomes
+// usable again and which account that is. An account's ready time is
+// the latest reset among its over-threshold windows — a 5h reset does
+// not help while the 7d window is still capped. Accounts whose binding
+// window carries no reset stamp are skipped: there is nothing to wait
+// for. ok is false when no account has a known ready time.
+func nextAvailability(
+	accounts map[int]store.Account,
+	cache usage.Cache,
+	thresholds usage.Thresholds,
+	now time.Time,
+) (time.Time, string, bool) {
+	var best time.Time
+	var bestEmail string
+	for _, acct := range accounts {
+		u, found := cachedUsage(cache, acct.CacheKey(), acct.Email)
+		if !found || u.TokenExpired {
+			continue
+		}
+		readyAt := now
+		unknown := false
+		for _, wc := range []struct {
+			win *usage.Window
+			cap int
+		}{
+			{u.FiveHour, thresholds.FiveHour},
+			{u.SevenDay, thresholds.SevenDay},
+		} {
+			if wc.win == nil || wc.win.Utilization < float64(wc.cap) {
+				continue
+			}
+			if wc.win.ResetsAt == nil {
+				unknown = true
+				break
+			}
+			if wc.win.ResetsAt.After(readyAt) {
+				readyAt = *wc.win.ResetsAt
+			}
+		}
+		if unknown {
+			continue
+		}
+		if bestEmail == "" || readyAt.Before(best) {
+			best = readyAt
+			bestEmail = acct.Email
+		}
+	}
+	return best, bestEmail, bestEmail != ""
 }
 
 func cachedUsage(cache usage.Cache, cacheKey, email string) (usage.AccountUsage, bool) {


### PR DESCRIPTION
Implements #12.

## Problem

When a rate-limit/threshold swap finds no usable account, the wrapper prints `staying on current account` and exits — an unattended session dies even though cux knows exactly when the next window resets.

## Change

- New `wait_for_reset` config key (default `true`), changing **only the give-up path**: compute the earliest instant any account becomes usable again, announce it, sleep until then (+90s slack for API-side clock skew), refresh usage, resolve a target again, and continue through the normal swap+resume flow.
- An account's ready time is the **latest** reset among its over-threshold windows — a 5h reset doesn't help while the 7d window is still capped. Accounts whose binding window has no `resets_at`, or whose token is expired, are skipped.
- Bounded retries (4) guard against skewed reset stamps; each retry waits for the next reset, so the loop never spins.
- Manual `/switch <target>` is excluded: a human asking for a specific account gets an immediate answer, not a multi-hour sleep.

## Tested on macOS 15 (arm64)

- `go vet ./...` clean, `gofmt` clean on touched files
- New table-driven test for the availability computation (`TestNextAvailability`, 5 cases: earliest-5h pick, 7d-cap binding over an earlier 5h reset, missing reset stamps + expired tokens, under-threshold short-circuit, lowered thresholds)
- Full `./internal/wrapper` and `./internal/config` suites pass

Happy to adapt this to the v0.3 background-monitor design if it conflicts.