### PR TITLE
feat: auto-continue after non-rate-limit API failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ cux config set update_check.enabled true            # opt in to update checks
 | `auto_switch_on_rate_limit`   | `true`         | Master toggle for swap on rate-limit hook |
 | `auto_resume`                 | `true`         | Pass `--resume <id>` to the relaunched claude |
 | `auto_message`                | `Go continue.` | First user turn after auto-swap; `""` = silent |
+| `retry_on_api_error`          | `true`         | Relaunch and auto-continue after a non-rate-limit API failure (fibonacci backoff, capped at 2 min) |
 | `update_check.enabled`        | `false`        | Check GitHub for newer cux releases on startup |
 | `update_check.cadence_hours`  | `6`            | Minimum hours between update checks (cached locally) |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	AutoSwitchOnRateLimit bool              `json:"auto_switch_on_rate_limit"`
 	AutoResume            bool              `json:"auto_resume"`
 	AutoMessage           string            `json:"auto_message"`
+	RetryOnAPIError       bool              `json:"retry_on_api_error"`
 	Notify                bool              `json:"notify"`
 	PollIntervalSeconds   int               `json:"poll_interval_seconds"`
 	UpdateCheck           UpdateCheckConfig `json:"update_check"`
@@ -87,6 +88,7 @@ func Defaults() Config {
 		AutoSwitchOnRateLimit: true,
 		AutoResume:            true,
 		AutoMessage:           "Go continue.",
+		RetryOnAPIError:       true,
 		Notify:                true,
 		PollIntervalSeconds:   60,
 		UpdateCheck:           UpdateCheckConfig{Enabled: true, CadenceHours: 6},
@@ -204,6 +206,12 @@ func Set(c Config, key, value string) (Config, error) {
 		} else {
 			c.AutoMessage = value
 		}
+	case "retry_on_api_error":
+		b, err := parseBool(value)
+		if err != nil {
+			return c, err
+		}
+		c.RetryOnAPIError = b
 	case "notify":
 		b, err := parseBool(value)
 		if err != nil {
@@ -297,6 +305,11 @@ func Keys(c Config) []KeyInfo {
 			Key: "auto_message", Default: "Go continue.",
 			Description: `first user turn after auto-swap; set to "" for silent resume`,
 			Current:     c.AutoMessage,
+		},
+		{
+			Key: "retry_on_api_error", Default: "true",
+			Description: "relaunch and auto-continue after a non-rate-limit API failure (fibonacci backoff)",
+			Current:     strconv.FormatBool(c.RetryOnAPIError),
 		},
 		{
 			Key: "notify", Default: "true",

--- a/internal/hooks/apifailure_test.go
+++ b/internal/hooks/apifailure_test.go
@@ -1,0 +1,100 @@
+package hooks
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/inulute/cux/internal/signals"
+)
+
+func rawStr(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+func TestClassifyFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		in   rateLimitHookInput
+		want signals.Name
+	}{
+		{
+			name: "rate limit stays a rate-limit swap",
+			in: rateLimitHookInput{
+				HookEventName: "StopFailure",
+				Error:         rawStr("rate_limit"),
+			},
+			want: signals.RateLimited,
+		},
+		{
+			name: "API error in the error field triggers a retry",
+			in: rateLimitHookInput{
+				HookEventName: "StopFailure",
+				Error:         rawStr("api_error: connection reset by peer"),
+			},
+			want: signals.TurnFailed,
+		},
+		{
+			name: "timeout wording in the assistant text alone must NOT trigger",
+			in: rateLimitHookInput{
+				HookEventName:        "StopFailure",
+				Error:                rawStr("prompt is too long"),
+				LastAssistantMessage: rawStr("the request timed out, let's add a 500ms timeout to the connection pool"),
+			},
+			want: "",
+		},
+		{
+			name: "tool failure with API-looking stderr must NOT trigger",
+			in: rateLimitHookInput{
+				HookEventName: "PostToolUseFailure",
+				Error:         rawStr("curl: (28) connection timed out after 5000 ms"),
+			},
+			want: "",
+		},
+		{
+			name: "rate limit wording in assistant text still swaps (existing behavior)",
+			in: rateLimitHookInput{
+				HookEventName:        "StopFailure",
+				Error:                rawStr("stopped"),
+				LastAssistantMessage: rawStr("You've hit your session limit."),
+			},
+			want: signals.RateLimited,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _ := classifyFailure(c.in)
+			if got != c.want {
+				t.Errorf("classifyFailure(%+v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsAPIFailure(t *testing.T) {
+	matches := []string{
+		"api_error: internal server error",
+		"connection refused",
+		"request timed out after 600000ms",
+		"fetch failed: socket hang up",
+		"502 bad gateway",
+		"getaddrinfo enotfound api.anthropic.com",
+	}
+	for _, s := range matches {
+		if !isAPIFailure(s) {
+			t.Errorf("isAPIFailure(%q) = false, want true", s)
+		}
+	}
+
+	nonMatches := []string{
+		"user aborted the request",
+		"prompt is too long: 215000 tokens > 200000 maximum",
+		"invalid_request_error: model not found",
+		"credit balance is too low",
+	}
+	for _, s := range nonMatches {
+		if isAPIFailure(s) {
+			t.Errorf("isAPIFailure(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,6 +67,7 @@ type rateLimitHookInput struct {
 	Error                json.RawMessage `json:"error,omitempty"`
 	ErrorDetails         json.RawMessage `json:"error_details,omitempty"`
 	LastAssistantMessage json.RawMessage `json:"last_assistant_message,omitempty"`
+	HookEventName        string          `json:"hook_event_name,omitempty"`
 }
 
 type userPromptSubmitHookInput struct {
@@ -942,17 +944,37 @@ func RateLimit(stdin io.Reader) error {
 		return nil
 	}
 
-	// Extract the error text from either JSON shape. StopFailure sends
-	// error="rate_limit" with optional error_details and last_assistant_message;
-	// PostToolUseFailure has historically put the useful text in error itself.
-	// Shape A — string:  "error": "rate limit exceeded"
-	// Shape B — object:  "error": {"type": "rate_limit_error", "message": "..."}
+	kind, message := classifyFailure(in)
+	switch kind {
+	case signals.RateLimited:
+		return signals.Write(pid, signals.RateLimited, signals.RateLimitedPayload{
+			Timestamp: time.Now().UTC(),
+			Message:   message,
+		})
+	case signals.TurnFailed:
+		return signals.Write(pid, signals.TurnFailed, signals.TurnFailedPayload{
+			Timestamp: time.Now().UTC(),
+			Message:   message,
+		})
+	}
+	return nil
+}
+
+// classifyFailure decides which signal (if any) a failure event should
+// produce, and the message to attach.
+//
+// Extracts the error text from either JSON shape. StopFailure sends
+// error="rate_limit" with optional error_details and last_assistant_message;
+// PostToolUseFailure has historically put the useful text in error itself.
+// Shape A — string:  "error": "rate limit exceeded"
+// Shape B — object:  "error": {"type": "rate_limit_error", "message": "..."}
+func classifyFailure(in rateLimitHookInput) (signals.Name, string) {
 	errText := extractErrorText(in.Error)
 	detailText := extractErrorText(in.ErrorDetails)
 	assistantText := extractErrorText(in.LastAssistantMessage)
 	combined := strings.Join(nonEmpty(errText, detailText, assistantText), "\n")
 	if combined == "" {
-		return nil
+		return "", ""
 	}
 
 	lower := strings.ToLower(combined)
@@ -964,21 +986,76 @@ func RateLimit(stdin io.Reader) error {
 		strings.Contains(lower, "overloaded_error") ||
 		strings.Contains(lower, "too many requests") ||
 		strings.Contains(lower, "429")
-	if !isRateLimit {
-		return nil
+
+	if isRateLimit {
+		message := assistantText
+		if message == "" {
+			message = detailText
+		}
+		if message == "" {
+			message = errText
+		}
+		return signals.RateLimited, message
 	}
 
-	message := assistantText
-	if message == "" {
-		message = detailText
+	// Non-rate-limit API failure. Two extra guards beyond the rate-limit
+	// path, because the failure patterns here (timeout, connection, 5xx)
+	// are words that legitimately appear all over normal conversations:
+	//
+	//   - Only StopFailure qualifies: it means the whole turn died after
+	//     Claude Code exhausted its own retries. PostToolUseFailure
+	//     routes through here too, but a tool's stderr saying
+	//     "connection timed out" is the tool's problem, not the API's.
+	//   - Only the structured error fields are searched — never
+	//     last_assistant_message. Claude discussing a timeout bug must
+	//     not read as the API timing out.
+	structuredErr := strings.ToLower(strings.Join(nonEmpty(errText, detailText), "\n"))
+	if in.HookEventName == "StopFailure" && isAPIFailure(structuredErr) {
+		failMsg := detailText
+		if failMsg == "" {
+			failMsg = errText
+		}
+		return signals.TurnFailed, failMsg
 	}
-	if message == "" {
-		message = errText
+	return "", ""
+}
+
+// apiStatusCode matches 5xx status codes as standalone tokens so a
+// number embedded in unrelated text ("215000 tokens") never counts.
+var apiStatusCode = regexp.MustCompile(`\b(500|502|503|504|529)\b`)
+
+// isAPIFailure reports whether an error string from StopFailure looks
+// like a transport- or server-side API failure worth retrying, as
+// opposed to something the user did (abort) or a model refusal.
+func isAPIFailure(lower string) bool {
+	for _, pat := range []string{
+		"api_error",
+		"api error",
+		"internal server error",
+		"internal_server_error",
+		"service unavailable",
+		"bad gateway",
+		"gateway timeout",
+		"connection error",
+		"connection refused",
+		"connection reset",
+		"connection closed",
+		"econnrefused",
+		"econnreset",
+		"etimedout",
+		"enotfound",
+		"eai_again",
+		"timed out",
+		"timeout",
+		"network error",
+		"fetch failed",
+		"socket hang up",
+	} {
+		if strings.Contains(lower, pat) {
+			return true
+		}
 	}
-	return signals.Write(pid, signals.RateLimited, signals.RateLimitedPayload{
-		Timestamp: time.Now().UTC(),
-		Message:   message,
-	})
+	return apiStatusCode.MatchString(lower)
 }
 
 // extractErrorText returns a plain string from a json.RawMessage that

--- a/internal/signals/signals.go
+++ b/internal/signals/signals.go
@@ -36,6 +36,7 @@ const (
 	Stopped         Name = "stopped"
 	RateLimited     Name = "rate-limited"
 	SwitchRequested Name = "switch-requested"
+	TurnFailed      Name = "turn-failed"
 )
 
 // Payloads. Match claude-revolver's shapes for hook-emitted signals so
@@ -64,6 +65,13 @@ type SwitchRequestedPayload struct {
 	Target        string    `json:"target,omitempty"`
 	ResumeMessage string    `json:"resumeMessage,omitempty"`
 	Timestamp     time.Time `json:"timestamp"`
+}
+
+// TurnFailedPayload marks a turn that died on a non-rate-limit API
+// error after Claude Code exhausted its own retries.
+type TurnFailedPayload struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message,omitempty"`
 }
 
 // Dir returns the absolute signal directory. Callers that intend to
@@ -175,6 +183,16 @@ func DecodeSwitchRequested(b []byte) (SwitchRequestedPayload, error) {
 // DecodeRateLimited is a convenience for the wrapper.
 func DecodeRateLimited(b []byte) (RateLimitedPayload, error) {
 	var p RateLimitedPayload
+	if len(b) == 0 {
+		return p, nil
+	}
+	err := json.Unmarshal(b, &p)
+	return p, err
+}
+
+// DecodeTurnFailed is a convenience for the wrapper.
+func DecodeTurnFailed(b []byte) (TurnFailedPayload, error) {
+	var p TurnFailedPayload
 	if len(b) == 0 {
 		return p, nil
 	}

--- a/internal/wrapper/retry_test.go
+++ b/internal/wrapper/retry_test.go
@@ -1,0 +1,28 @@
+package wrapper
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFibonacciDelay(t *testing.T) {
+	want := []time.Duration{
+		10 * time.Second, // attempt 0
+		10 * time.Second,
+		20 * time.Second,
+		30 * time.Second,
+		50 * time.Second,
+		80 * time.Second,
+		2 * time.Minute, // capped from here on
+		2 * time.Minute,
+	}
+	for n, exp := range want {
+		if got := fibonacciDelay(n); got != exp {
+			t.Errorf("fibonacciDelay(%d) = %v, want %v", n, got, exp)
+		}
+	}
+	// Large n must stay capped and not overflow.
+	if got := fibonacciDelay(1000); got != 2*time.Minute {
+		t.Errorf("fibonacciDelay(1000) = %v, want %v", got, 2*time.Minute)
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -68,6 +68,7 @@ type pending struct {
 	reason         string
 	explicitTarget string
 	resumeMessage  string
+	retryOnly      bool               // relaunch the same account; no swap
 	fromUsage      usage.AccountUsage // best-effort snapshot
 }
 
@@ -124,12 +125,42 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 	}
 
 	var resumeRetryPending bool
+	// apiRetries counts consecutive same-account relaunches after API
+	// failures; it scales the fibonacci backoff and resets whenever a
+	// turn completes or claude exits for any other reason. There is no
+	// upper bound by design: an unattended session should outlast even
+	// a multi-hour outage, and a human can always Ctrl+C.
+	var apiRetries int
 
 	for {
 		exitCode, sessionID, hadTurns, p, err := launch(claudeBin, currentArgv, pid, &cfg, lastManualTarget, w)
 		if err != nil {
 			return exitCode, err
 		}
+
+		if p != nil && p.retryOnly {
+			if hadTurns {
+				apiRetries = 0
+			}
+			delay := fibonacciDelay(apiRetries)
+			apiRetries++
+			fmt.Fprintf(w, "cux: API failure after claude's own retries (%s) — auto-continuing in %s (attempt %d)…\n",
+				snippet(p.reason), shortDuration(delay), apiRetries)
+			time.Sleep(delay)
+			if sessionID != "" && cfg.AutoResume {
+				cwd, _ := os.Getwd()
+				waitForTranscript(cwd, sessionID, transcriptWaitTimeout)
+				currentArgv = []string{"--resume", sessionID}
+				if cfg.AutoMessage != "" {
+					currentArgv = append(currentArgv, cfg.AutoMessage)
+				}
+				resumeRetryPending = true
+			} else {
+				currentArgv = argv
+			}
+			continue
+		}
+		apiRetries = 0
 
 		if p == nil && resumeRetryPending && isResumeArgv(currentArgv) && exitCode != 0 {
 			resumeRetryPending = false
@@ -419,6 +450,31 @@ func step(
 			}
 		} else {
 			fmt.Fprintln(w, "cux: rate-limit hook fired but auto_switch_on_rate_limit is off; staying on current account")
+		}
+	}
+
+	// 2b. Non-rate-limit API failure ⇒ relaunch the same account after
+	//     a backoff. The turn is already dead (StopFailure fires only
+	//     after Claude Code exhausted its own retries), so like the
+	//     rate-limit case there may be no later Stop event to wait for.
+	if b, ok, _ := signals.Read(wrapperPID, signals.TurnFailed); ok {
+		_ = signals.Consume(wrapperPID, signals.TurnFailed)
+		if cfg.RetryOnAPIError {
+			hasSwap := false
+			mu.Lock()
+			if *swap == nil {
+				msg := "API error after retries"
+				if p, err := signals.DecodeTurnFailed(b); err == nil && p.Message != "" {
+					msg = p.Message
+				}
+				*swap = &pending{retryOnly: true, reason: msg}
+			}
+			hasSwap = *swap != nil
+			mu.Unlock()
+			if hasSwap && stopRequested.CompareAndSwap(false, true) {
+				go gracefulExit(cmd, w)
+				return
+			}
 		}
 	}
 
@@ -871,6 +927,36 @@ func accountHasSwitchCapacity(cache usage.Cache, cacheKey string, cfg *config.Co
 		cap5 = 90
 	}
 	return u.FiveHour == nil || u.FiveHour.Utilization < float64(cap5)
+}
+
+const (
+	retryBaseDelay = 10 * time.Second
+	retryMaxDelay  = 2 * time.Minute
+)
+
+// fibonacciDelay returns the wait before auto-continue attempt n
+// (0-based): 10s, 10s, 20s, 30s, 50s, 80s, then capped at 2 minutes.
+// The clock starts only after StopFailure fires — Claude Code has
+// already burned through its own internal retries by then — so there
+// is no reason to start slower.
+func fibonacciDelay(n int) time.Duration {
+	a, b := 1, 1
+	for i := 0; i < n; i++ {
+		a, b = b, a+b
+		if time.Duration(a)*retryBaseDelay >= retryMaxDelay {
+			return retryMaxDelay
+		}
+	}
+	return time.Duration(a) * retryBaseDelay
+}
+
+// snippet trims an error message down to a single displayable line.
+func snippet(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > 120 {
+		return s[:117] + "..."
+	}
+	return s
 }
 
 func isResumeArgv(argv []string) bool {


### PR DESCRIPTION
Implements #14.

## Problem

When an API failure outlasts Claude Code's internal retries, StopFailure fires, cux finds no rate-limit pattern, and the session sits idle waiting for input — an unattended run stays parked until a human returns, even after the API recovers.

## Change

- `classifyFailure` (extracted from the RateLimit handler, existing behavior preserved and now unit-tested) additionally recognises transport/server failures — api_error, standalone-token 5xx, connection/timeout/DNS families — and emits a new `turn-failed` signal.
- The wrapper relaunches the **same** account with `--resume <id>` + `auto_message` on a fibonacci backoff: 10s, 10s, 20s, 30s, 50s, 80s, capped at 2 minutes per gap. The clock starts after StopFailure — Claude Code has already burned through its own retries by then. Unbounded by design (a multi-hour outage should not kill the run; Ctrl+C always works); resets once a turn completes.
- New config key `retry_on_api_error` (default `true`).

## False-positive guards (both unit-tested)

- Only **StopFailure** qualifies — PostToolUseFailure with API-looking tool stderr ("curl: connection timed out") does not signal.
- Only the **structured error fields** are searched, never `last_assistant_message` — Claude discussing a timeout bug must not read as the API timing out. 5xx codes match as standalone tokens only ("215000 tokens" ≠ "500").

## Tested on macOS 15 (arm64)

- `go vet ./...` clean, `gofmt` clean on touched files
- New tests: `TestClassifyFailure` (5 cases incl. both false-positive guards and existing rate-limit behavior), `TestIsAPIFailure`, `TestFibonacciDelay` (incl. overflow/cap at large n)
- Full `./internal/hooks`, `./internal/wrapper`, `./internal/config` suites pass (hooks suite has a pre-existing macOS isolation failure — see #7)