### PR TITLE
fix: isolate tests from the real keychain and ~/.cux on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ go build -o cux ./cmd/cux
 
 Requires Go 1.21+.
 
+`go test ./...` is safe to run next to a real cux setup: the suite
+redirects HOME/XDG into temp dirs and forces the file credential
+backend (`CUX_CREDS_BACKEND=file`), so it never touches your actual
+state, usage cache, or OS keychain.
+
 ## License
 
 [GPL-3.0-only](./LICENSE). Modifying and redistributing `cux` is

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -67,10 +67,23 @@ const (
 // (user never logged in, or just logged out).
 var ErrNotFound = errors.New("creds: live credentials not found")
 
+// envCredsBackend forces the plain-file storage backend on any
+// platform when set to "file". Its primary purpose is test isolation:
+// on macOS/Windows both the live and backup stores live in the OS
+// keystore, which HOME/XDG_DATA_HOME redirection cannot reach, so
+// without this a `go test` run reads — and can write — the real
+// keychain (issue #7). File paths, by contrast, all resolve through
+// HOME/XDG and land inside the test's temp directory.
+const envCredsBackend = "CUX_CREDS_BACKEND"
+
+func fileBackendForced() bool {
+	return os.Getenv(envCredsBackend) == "file"
+}
+
 // ReadLive returns the active credential blob Claude Code is currently
 // using. The format is an opaque JSON string — we don't parse it.
 func ReadLive() (string, error) {
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" && !fileBackendForced() {
 		return readLiveMacOS()
 	}
 	return readLiveFile()
@@ -83,7 +96,7 @@ func WriteLive(blob string) error {
 	if blob == "" {
 		return errors.New("creds: refusing to write empty live credentials")
 	}
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" && !fileBackendForced() {
 		return writeLiveMacOS(blob)
 	}
 	return writeLiveFile(blob)
@@ -92,7 +105,7 @@ func WriteLive(blob string) error {
 // ReadBackup returns the saved credential blob for one account, or
 // ErrNotFound if there is no backup for it.
 func ReadBackup(slot int, email string) (string, error) {
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" || fileBackendForced() {
 		return readBackupFile(slot, email)
 	}
 	return readBackupKeyring(slot, email)
@@ -103,7 +116,7 @@ func WriteBackup(slot int, email, blob string) error {
 	if blob == "" {
 		return errors.New("creds: refusing to write empty backup credentials")
 	}
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" || fileBackendForced() {
 		return writeBackupFile(slot, email, blob)
 	}
 	return writeBackupKeyring(slot, email, blob)
@@ -248,7 +261,7 @@ func RefreshBlob(blob string) (string, error) {
 // DeleteBackup removes the saved credential blob for one account.
 // Missing entries are not an error — deletion is idempotent.
 func DeleteBackup(slot int, email string) error {
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" || fileBackendForced() {
 		return deleteBackupFile(slot, email)
 	}
 	return deleteBackupKeyring(slot, email)

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -17,6 +17,7 @@ import (
 func withTempBackup(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	t.Setenv("HOME", dir)
 	t.Setenv("XDG_DATA_HOME", dir)
 	// Make sure no stale file from a prior run exists at the path
 	// paths.BackupRoot will compute under our temp XDG_DATA_HOME.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/inulute/cux/internal/paths"
 	"github.com/inulute/cux/internal/signals"
 	"github.com/inulute/cux/internal/store"
 	"github.com/inulute/cux/internal/usage"
@@ -24,7 +25,9 @@ func TestRenderPromptSupportIncludesURL(t *testing.T) {
 }
 
 func TestRenderPromptUsageReportsAllExhaustedAtEffectiveCaps(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 	t.Setenv("CUX_CONFIG_FILE", t.TempDir()+"/config.json")
 
 	state := &store.State{
@@ -62,7 +65,9 @@ func TestRenderPromptUsageReportsAllExhaustedAtEffectiveCaps(t *testing.T) {
 
 func TestUserPromptSubmitBareSwitchBlocksWhenAllAccountsExhausted(t *testing.T) {
 	t.Setenv("CUX_WRAPPED", "1")
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 	t.Setenv("CUX_CONFIG_FILE", t.TempDir()+"/config.json")
 
 	state := &store.State{
@@ -114,9 +119,12 @@ func TestUserPromptSubmitBareSwitchBlocksWhenAllAccountsExhausted(t *testing.T) 
 func TestHandleAutoSwitchPrompt_HardBlock_Threshold100(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("CUX_WRAPPED", "1")
-	// Redirect HOME and XDG_DATA_HOME so all paths resolve under tmp.
+	// Redirect HOME and XDG_DATA_HOME so all paths resolve under tmp,
+	// and force the file credential backend so macOS does not read or
+	// write the real keychain (issue #7).
 	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 	t.Setenv("CUX_CONFIG_FILE", filepath.Join(tmp, "config.json"))
 
 	// Write a minimal fake Claude config so CurrentLiveEmail() returns
@@ -136,7 +144,10 @@ func TestHandleAutoSwitchPrompt_HardBlock_Threshold100(t *testing.T) {
 	// RefreshAll's refreshOne call hits ExtractAccessToken error and
 	// returns before making a real API call — avoiding a 401 that would
 	// mark the account as TokenExpired and prevent PickNext from selecting it.
-	acct2Dir := filepath.Join(tmp, "cux", "accounts", "02-free@x.test")
+	// Resolve the directory through paths.AccountDir rather than
+	// hand-building it: the backup root differs per platform (XDG on
+	// Linux, ~/.cux elsewhere) and a hardcoded layout only matched Linux.
+	acct2Dir := paths.AccountDir(2, "free@x.test")
 	if err := os.MkdirAll(acct2Dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +217,9 @@ func TestHandleAutoSwitchPrompt_HardBlock_Threshold100(t *testing.T) {
 func TestRateLimitStopFailureWritesSignal(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("CUX_WRAPPED", "1")
+	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 	pid := os.Getpid()
 	t.Setenv("CUX_WRAPPER_PID", fmt.Sprintf("%d", pid))
 

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -19,6 +19,7 @@ func TestSyncLiveIfActiveWritesOnlyMatchingLiveAccount(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, ".local", "share"))
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 
 	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o700); err != nil {
 		t.Fatal(err)
@@ -66,6 +67,7 @@ func TestRefreshAllCreatesDataDirBeforeLock(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, ".local", "share"))
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 
 	if _, err := os.Stat(paths.BackupRoot()); !os.IsNotExist(err) {
 		t.Fatalf("backup root should not exist before refresh, stat err = %v", err)
@@ -87,6 +89,7 @@ func TestRefreshAllReportsUnreadableUsageCache(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, ".local", "share"))
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 
 	runtimeDir := paths.RuntimeDir()
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestResolveTargetDoesNotRotateToWeeklyFullFallback(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 
 	state := &store.State{
 		ActiveSlot: 1,
@@ -80,6 +82,7 @@ func TestEvaluatePrelaunchHardLimitSwapUsesRateLimitTrigger(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 	claudeDir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
 		t.Fatal(err)
@@ -133,6 +136,7 @@ func TestEvaluatePrelaunchHardLimitSwapBlocksWhenAllAccountsFull(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("CUX_CREDS_BACKEND", "file")
 	claudeDir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #7.

## Problem

Tests isolated themselves with `XDG_DATA_HOME`, which `paths.BackupRoot` only honors on Linux. On macOS:

- every `state.Save()` in the hooks/wrapper fixtures landed in the **real** `~/.cux/state.json` — running `go test ./...` replaced a user's managed accounts with `a@x.test` / `b@x.test`
- the credential fixtures missed entirely: `creds` reads the real keychain on darwin, so `TestHandleAutoSwitchPrompt_HardBlock_Threshold100` failed on any Mac with live Claude credentials — and a fixture write could have gone *into* the real keychain

## Change

Of the two options floated in #7, this takes the env-override route, but scoped to the credential backend rather than a new data-dir variable (state/cache/history already isolate fine once `HOME` is set, since `BackupRoot` falls back to `$HOME/.cux`):

- **`creds`**: a `CUX_CREDS_BACKEND=file` env override forces the plain-file backend on any platform. File paths all resolve through `HOME`/`XDG`, so redirected tests stay inside their temp dirs — the OS keystore is unreachable by construction. No behavior change when the variable is unset.
- **tests**: set `HOME` (where missing) and `CUX_CREDS_BACKEND=file` in every fixture that touches state, usage cache, history, or credentials (`hooks`, `wrapper`, `monitor`, `history`).
- **the hard-block fixture** resolves its backup dir through `paths.AccountDir` instead of hand-building the Linux XDG layout (`$XDG/cux/accounts/02-…`) — that hardcoded path is why the test could never pass on macOS even where `HOME` *was* redirected.

## Verification (macOS 15, arm64, real cux setup present)

- `go vet ./...` clean, `gofmt` clean on touched files
- Full `go test ./... -count=1` passes — including `TestHandleAutoSwitchPrompt_HardBlock_Threshold100`, which failed on a clean `main` checkout here
- `~/.cux/state.json` SHA-256 identical before and after the full run; no `cux-backup` keychain entries created for fixture accounts
- Linux semantics unchanged: `XDG_DATA_HOME` still governs `BackupRoot`, and the file backend remains the default there