### PR TITLE
fix: keep resuming across consecutive swaps instead of falling back to the session picker

### DIFF
--- a/internal/wrapper/resumable_test.go
+++ b/internal/wrapper/resumable_test.go
@@ -1,0 +1,70 @@
+package wrapper
+
+import "testing"
+
+func TestResumableSession(t *testing.T) {
+	cases := []struct {
+		name       string
+		sessionID  string
+		argv       []string
+		autoResume bool
+		hadTurns   bool
+		wantSID    string
+		wantOK     bool
+	}{
+		{
+			name:      "turn completed resumes the hook-reported session",
+			sessionID: "sid-1", argv: []string{"--verbose"},
+			autoResume: true, hadTurns: true,
+			wantSID: "sid-1", wantOK: true,
+		},
+		{
+			name:      "auto_resume off never resumes",
+			sessionID: "sid-1", argv: []string{"--resume", "sid-1"},
+			autoResume: false, hadTurns: true,
+			wantSID: "", wantOK: false,
+		},
+		{
+			name:      "fresh session with no completed turn has nothing to resume",
+			sessionID: "sid-1", argv: []string{"--verbose"},
+			autoResume: true, hadTurns: false,
+			wantSID: "", wantOK: false,
+		},
+		{
+			// The overnight-picker regression: a relaunch that was itself
+			// resuming dies before completing a turn (second rate limit in
+			// a row). Its transcript exists — keep resuming it.
+			name:      "consecutive swap without a completed turn keeps resuming",
+			sessionID: "sid-1", argv: []string{"--resume", "sid-1", "Go continue."},
+			autoResume: true, hadTurns: false,
+			wantSID: "sid-1", wantOK: true,
+		},
+		{
+			name:      "session id recovered from argv when the hook missed it",
+			sessionID: "", argv: []string{"--resume", "sid-from-argv"},
+			autoResume: true, hadTurns: false,
+			wantSID: "sid-from-argv", wantOK: true,
+		},
+		{
+			name:      "bare --resume with no known session cannot resume",
+			sessionID: "", argv: []string{"--dangerously-skip-permissions", "--resume"},
+			autoResume: true, hadTurns: false,
+			wantSID: "", wantOK: false,
+		},
+		{
+			name:      "flag after bare --resume is not mistaken for a session id",
+			sessionID: "", argv: []string{"--resume", "--verbose"},
+			autoResume: true, hadTurns: false,
+			wantSID: "", wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sid, ok := resumableSession(c.sessionID, c.argv, c.autoResume, c.hadTurns)
+			if sid != c.wantSID || ok != c.wantOK {
+				t.Errorf("resumableSession(%q, %v, %v, %v) = (%q, %v), want (%q, %v)",
+					c.sessionID, c.argv, c.autoResume, c.hadTurns, sid, ok, c.wantSID, c.wantOK)
+			}
+		})
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -147,13 +147,16 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			fmt.Fprintf(w, "cux: API failure after claude's own retries (%s) — auto-continuing in %s (attempt %d)…\n",
 				snippet(p.reason), shortDuration(delay), apiRetries)
 			time.Sleep(delay)
-			if sessionID != "" && cfg.AutoResume {
+			// A StopFailure implies a session existed and a turn was
+			// attempted, so treat a hook-reported session as resumable
+			// even without a completed turn.
+			if resumeSID, ok := resumableSession(sessionID, currentArgv, cfg.AutoResume, sessionID != ""); ok {
 				cwd, _ := os.Getwd()
-				waitForTranscript(cwd, sessionID, transcriptWaitTimeout)
+				waitForTranscript(cwd, resumeSID, transcriptWaitTimeout)
 				// Preserve the user's original flags (e.g.
 				// --dangerously-skip-permissions, --model) on the retry
 				// relaunch, same as the swap path below (#11).
-				currentArgv = append(relaunchFlags(argv), "--resume", sessionID)
+				currentArgv = append(relaunchFlags(argv), "--resume", resumeSID)
 				if cfg.AutoMessage != "" {
 					currentArgv = append(currentArgv, cfg.AutoMessage)
 				}
@@ -255,11 +258,8 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			setManualSwitchState("")
 		}
 
-		canResume := sessionID != "" && cfg.AutoResume && hadTurns
+		resumeSID, canResume := resumableSession(sessionID, currentArgv, cfg.AutoResume, hadTurns)
 		if canResume {
-			// Only resume if at least one turn completed — an empty/just-started
-			// session has no transcript content and claude rejects --resume for it.
-			// This applies to all trigger types including manual /switch.
 			switch p.trigger {
 			case history.TriggerRateLimit:
 				fmt.Fprintf(w, "cux: rate limit on %s → swapped to %s, resuming…\n", from.Email, to.Email)
@@ -268,8 +268,8 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			default:
 				fmt.Fprintf(w, "cux: %s → %s (%s), resuming…\n", from.Email, to.Email, p.reason)
 			}
-			waitForTranscript(cwd, sessionID, transcriptWaitTimeout)
-			currentArgv = append(relaunchFlags(argv), "--resume", sessionID)
+			waitForTranscript(cwd, resumeSID, transcriptWaitTimeout)
+			currentArgv = append(relaunchFlags(argv), "--resume", resumeSID)
 			if p.resumeMessage != "" {
 				// Write a one-shot flag so the UserPromptSubmit hook skips the
 				// threshold check for this replayed prompt. Without this, if the
@@ -1124,6 +1124,39 @@ func snippet(s string) string {
 		return s[:117] + "..."
 	}
 	return s
+}
+
+// resumableSession decides whether the wrapper can relaunch into an
+// existing session after a swap, and which session id to use.
+// sessionID is what the SessionStart hook reported for the run that
+// just exited; argv is that run's launch argv.
+//
+// A completed turn (hadTurns) is the usual proof a transcript exists —
+// an empty, just-started session has nothing to resume and claude
+// rejects --resume for it. But a run that was itself resuming an
+// earlier session has a transcript by definition, even when it died
+// before completing a new turn (e.g. a swap landing on an account that
+// rate-limits during the very first replayed prompt). Falling back to
+// the original argv in that case is what stranded unattended runs: a
+// bare `--resume` in it opens the interactive session picker, which
+// nobody is around to answer at 3am.
+func resumableSession(sessionID string, argv []string, autoResume, hadTurns bool) (string, bool) {
+	if !autoResume {
+		return "", false
+	}
+	sid := sessionID
+	if sid == "" {
+		if v := resumeSessionID(argv); v != "" && !strings.HasPrefix(v, "-") {
+			sid = v
+		}
+	}
+	if sid == "" {
+		return "", false
+	}
+	if hadTurns || isResumeArgv(argv) {
+		return sid, true
+	}
+	return "", false
 }
 
 func isResumeArgv(argv []string) bool {


### PR DESCRIPTION
Fixes #17. Supersedes #18 (same change, rebuilt as a single clean commit on top of v0.2.11 main — no force-pushed history this time).

## Problem

A relaunch that dies before completing its first turn (second rate limit in a row, exhausted swap target) fell back to the original argv. A bare `--resume` there opens the interactive session picker mid-run — an unattended overnight session sits on it until a human returns.

## Change

- New `resumableSession(sessionID, argv, autoResume, hadTurns)` helper: resume when a turn completed **or** the exited run was itself resuming (its transcript exists by definition — the `hadTurns` gate is only needed for genuinely fresh sessions, where claude rejects `--resume`).
- Recovers the session id from the exited run's argv when the SessionStart hook didn't report one; a flag token after a bare `--resume` is never mistaken for a session id.
- The StopFailure retry path (#15) uses the same helper: a failed turn implies the session existed, so a hook-reported session stays resumable there too.
- No behavior change for fresh sessions without a completed turn — those still fall back to the original argv, as before.

## Tested on macOS 15 (arm64), on top of v0.2.11 main

- `go vet ./...` clean, `gofmt` clean on touched files
- New table-driven `TestResumableSession` (7 cases incl. the consecutive-swap regression, argv-recovered session id, bare `--resume`, and flag-after-`--resume`)
- Full `go test ./...` passes (12 packages)