### PR TITLE
fix: reap orphaned descendants after a swap so they cannot fight for stdin

### DIFF
--- a/internal/wrapper/proctree.go
+++ b/internal/wrapper/proctree.go
@@ -1,0 +1,142 @@
+package wrapper
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Reaping orphaned descendants.
+//
+// claudeBin is not always the claude binary itself: users wrap it in
+// scripts that chain other tools (cux → headroom → claude, issue #3).
+// gracefulExit signals only the direct child, and a dying shell does
+// not forward signals to its children — so the grandchildren survive
+// the swap, stay attached to the terminal, and fight the relaunched
+// claude for stdin: keystrokes split between the two, characters
+// appear and vanish. The fix is to snapshot the child's descendants
+// before signalling and reap whatever is still alive after it exits.
+
+const (
+	strayTermGrace = 2 * time.Second
+	strayScanDelay = 500 * time.Millisecond
+)
+
+// descendantPIDs returns every live descendant of pid by walking the
+// ps table. Best-effort: returns nil on any error (including
+// platforms without ps, like Windows) — the caller then simply keeps
+// today's direct-child-only behavior.
+func descendantPIDs(pid int) []int {
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=").Output()
+	if err != nil {
+		return nil
+	}
+	return collectDescendants(parsePSTable(out), pid)
+}
+
+// parsePSTable turns `ps -axo pid=,ppid=` output into a parent → children map.
+func parsePSTable(out []byte) map[int][]int {
+	children := make(map[int][]int)
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		pid, err1 := strconv.Atoi(fields[0])
+		ppid, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		children[ppid] = append(children[ppid], pid)
+	}
+	return children
+}
+
+// collectDescendants walks the children map depth-first from root.
+// The root itself is not included.
+func collectDescendants(children map[int][]int, root int) []int {
+	var out []int
+	stack := append([]int(nil), children[root]...)
+	for len(stack) > 0 {
+		pid := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		out = append(out, pid)
+		stack = append(stack, children[pid]...)
+	}
+	return out
+}
+
+// processAlive reports whether pid still exists, via the null signal.
+// On platforms where that probe is unsupported it reports false, which
+// degrades to a no-op reap.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+// reapStrays terminates any of the snapshotted descendants that
+// outlived the direct child: SIGTERM first, a short grace period,
+// then SIGKILL for whatever remains. Processes that already exited
+// (the common case — claude cleans up after itself) are untouched.
+func reapStrays(pids []int, w io.Writer) {
+	if len(pids) == 0 {
+		return
+	}
+	// Give the tree a moment to fall on its own after the parent died.
+	time.Sleep(strayScanDelay)
+
+	var strays []int
+	for _, pid := range pids {
+		if processAlive(pid) {
+			strays = append(strays, pid)
+		}
+	}
+	if len(strays) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "cux: reaping %d stray child process(es) left behind by the previous claude\n", len(strays))
+	for _, pid := range strays {
+		if p, err := os.FindProcess(pid); err == nil {
+			_ = p.Signal(syscall.SIGTERM)
+		}
+	}
+
+	deadline := time.After(strayTermGrace)
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-deadline:
+			for _, pid := range strays {
+				if processAlive(pid) {
+					if p, err := os.FindProcess(pid); err == nil {
+						_ = p.Kill()
+					}
+				}
+			}
+			return
+		case <-tick.C:
+			anyAlive := false
+			for _, pid := range strays {
+				if processAlive(pid) {
+					anyAlive = true
+					break
+				}
+			}
+			if !anyAlive {
+				return
+			}
+		}
+	}
+}

--- a/internal/wrapper/proctree_test.go
+++ b/internal/wrapper/proctree_test.go
@@ -1,0 +1,82 @@
+package wrapper
+
+import (
+	"io"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"sort"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestParsePSTable(t *testing.T) {
+	out := []byte("  1     0\n  10    1\n  11    1\n  20   10\ngarbage line\n  30\n")
+	got := parsePSTable(out)
+	want := map[int][]int{0: {1}, 1: {10, 11}, 10: {20}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parsePSTable = %v, want %v", got, want)
+	}
+}
+
+func TestCollectDescendants(t *testing.T) {
+	children := map[int][]int{1: {10, 11}, 10: {20}, 20: {30}, 11: {}}
+	got := collectDescendants(children, 1)
+	sort.Ints(got)
+	want := []int{10, 11, 20, 30}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("collectDescendants = %v, want %v", got, want)
+	}
+	if desc := collectDescendants(children, 99); desc != nil {
+		t.Errorf("unknown root should have no descendants, got %v", desc)
+	}
+}
+
+// TestReapStraysKillsOrphanedGrandchildren reproduces issue #3's shape:
+// a wrapper script whose children outlive it. The direct child dies
+// without forwarding anything; reapStrays must clean up the orphans.
+func TestReapStraysKillsOrphanedGrandchildren(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ps-based reaping is a no-op on windows")
+	}
+
+	// sh spawns two background sleeps (grandchildren) and waits.
+	cmd := exec.Command("sh", "-c", "sleep 300 & sleep 300 & wait")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// Let the shell fork its children, then snapshot the tree.
+	var strays []int
+	for i := 0; i < 50; i++ {
+		strays = descendantPIDs(cmd.Process.Pid)
+		if len(strays) >= 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(strays) < 2 {
+		t.Fatalf("expected at least 2 descendants, got %v", strays)
+	}
+
+	// Kill the direct child the hard way — nothing is forwarded, the
+	// sleeps become orphans still holding their file descriptors.
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	reapStrays(strays, io.Discard)
+
+	for _, pid := range strays {
+		if processAlive(pid) {
+			_ = syscall.Kill(pid, syscall.SIGKILL) // don't leak on failure
+			t.Errorf("pid %d survived reapStrays", pid)
+		}
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -909,6 +909,13 @@ func gracefulExit(cmd *exec.Cmd, w io.Writer) {
 	if cmd.Process == nil {
 		return
 	}
+	// Snapshot the descendant tree before signalling: claudeBin may be
+	// a wrapper script chaining other tools (cux → headroom → claude,
+	// issue #3). The SIGINT below reaches only the direct child, and a
+	// dying shell does not forward it — grandchildren would survive,
+	// stay attached to the terminal, and fight the relaunched claude
+	// for stdin.
+	strays := descendantPIDs(cmd.Process.Pid)
 	_ = cmd.Process.Signal(os.Interrupt)
 
 	deadline := time.NewTimer(gracefulExitWait)
@@ -921,9 +928,11 @@ func gracefulExit(cmd *exec.Cmd, w io.Writer) {
 		case <-deadline.C:
 			fmt.Fprintln(w, "cux: claude did not exit cleanly, terminating…")
 			_ = cmd.Process.Kill()
+			reapStrays(strays, w)
 			return
 		case <-tick.C:
 			if cmd.ProcessState != nil {
+				reapStrays(strays, w)
 				return
 			}
 		}


### PR DESCRIPTION
Fixes #3.

## Root cause

@neillfontes-klar chains `cux → hr-claude (script) → headroom → claude`. `gracefulExit` sends SIGINT (and, on timeout, SIGKILL) to the **direct child only** — the wrapper script. A dying shell does not forward signals to its children, so the grandchildren (headroom/claude) survive the swap, get reparented, and **stay attached to the terminal**. The relaunched claude then shares stdin with the orphaned one: each keystroke lands in whichever process reads first — exactly the "characters are backtracked and the input gets lost" symptom.

## Change

- Snapshot the direct child's descendant tree (one `ps -axo pid=,ppid=` walk) **before** signalling — after the child dies the ppid chain is gone.
- After the child exits (both the clean and the timeout path), reap whatever survived: 500ms settle, liveness probe via the null signal, SIGTERM, 2s grace, SIGKILL for stragglers.
- The common case — claude run directly, cleaning up its own children on SIGINT — finds nothing alive and reaps nothing.
- Platforms without `ps` (Windows) degrade to today's direct-child-only behavior.

## Tested on macOS 15 (arm64)

- Pure tests for the ps-table parser and the tree walk
- An integration test reproducing the issue's shape: a `sh` child spawns two background sleeps, gets SIGKILLed (nothing forwarded), and `reapStrays` cleans up the orphans
- `go vet ./...` clean, full `go test ./...` passes (12 packages)

## Note for the reporter's setup

Independent of this fix, `hr-claude`-style wrapper scripts should `exec` their final command (`exec headroom claude "$@"`) so the script doesn't linger as an extra layer; with this patch even non-`exec` scripts are cleaned up correctly.