### PR TITLE
fix: stop concurrent sessions from cascading through the account pool

### DIFF
--- a/internal/wrapper/concurrent_test.go
+++ b/internal/wrapper/concurrent_test.go
@@ -1,0 +1,105 @@
+package wrapper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/inulute/cux/internal/config"
+	"github.com/inulute/cux/internal/store"
+	"github.com/inulute/cux/internal/usage"
+)
+
+// isolateLive sets up a temp HOME with a fake live login plus managed
+// state, mirroring what another concurrent session leaves behind after
+// swapping the live account.
+func isolateLive(t *testing.T, liveEmail string, cache usage.Cache) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("CUX_CREDS_BACKEND", "file")
+	t.Setenv("CUX_CONFIG_FILE", filepath.Join(tmp, "config.json"))
+
+	claudeDir := filepath.Join(tmp, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	claudeJSON := `{"oauthAccount":{"emailAddress":"` + liveEmail + `","accountUuid":"u-live"}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, ".claude.json"), []byte(claudeJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state := &store.State{
+		ActiveSlot: 2,
+		Sequence:   []int{1, 2},
+		Accounts: map[int]store.Account{
+			1: {Slot: 1, Email: "limited@x.test"},
+			2: {Slot: 2, Email: "fresh@x.test"},
+		},
+	}
+	if err := state.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.SaveCache(cache); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveAccountWithCapacity(t *testing.T) {
+	cfg := config.Defaults()
+
+	t.Run("healthy live account skips the swap", func(t *testing.T) {
+		// Another session already swapped live to fresh@x.test.
+		isolateLive(t, "fresh@x.test", usage.Cache{
+			"limited@x.test": hookStyleUsage(100, 40),
+			"fresh@x.test":   hookStyleUsage(5, 10),
+		})
+		acct, ok := liveAccountWithCapacity(&cfg)
+		if !ok || acct.Email != "fresh@x.test" {
+			t.Errorf("got (%q, %v), want (fresh@x.test, true)", acct.Email, ok)
+		}
+	})
+
+	t.Run("exhausted live account does not skip", func(t *testing.T) {
+		isolateLive(t, "limited@x.test", usage.Cache{
+			"limited@x.test": hookStyleUsage(100, 40),
+			"fresh@x.test":   hookStyleUsage(5, 10),
+		})
+		if _, ok := liveAccountWithCapacity(&cfg); ok {
+			t.Error("expected ok=false for an exhausted live account")
+		}
+	})
+
+	t.Run("no usage data means no skip", func(t *testing.T) {
+		isolateLive(t, "fresh@x.test", usage.Cache{})
+		if _, ok := liveAccountWithCapacity(&cfg); ok {
+			t.Error("expected ok=false without usage data")
+		}
+	})
+
+	t.Run("unmanaged live account does not skip", func(t *testing.T) {
+		isolateLive(t, "stranger@x.test", usage.Cache{
+			"fresh@x.test": hookStyleUsage(5, 10),
+		})
+		if _, ok := liveAccountWithCapacity(&cfg); ok {
+			t.Error("expected ok=false for an unmanaged live account")
+		}
+	})
+
+	t.Run("expired token does not skip", func(t *testing.T) {
+		u := hookStyleUsage(5, 10)
+		u.TokenExpired = true
+		isolateLive(t, "fresh@x.test", usage.Cache{"fresh@x.test": u})
+		if _, ok := liveAccountWithCapacity(&cfg); ok {
+			t.Error("expected ok=false for an expired token")
+		}
+	})
+}
+
+func hookStyleUsage(five, seven float64) usage.AccountUsage {
+	return usage.AccountUsage{
+		FiveHour: &usage.Window{Utilization: five},
+		SevenDay: &usage.Window{Utilization: seven},
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -194,56 +194,72 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			return exitCode, nil
 		}
 
-		target, err := resolveTarget(p.explicitTarget, p.trigger, &cfg)
-		if err != nil {
-			if p.trigger == history.TriggerRateLimit || p.trigger == history.TriggerThreshold {
-				_, _ = monitor.RefreshAll()
-				target, err = resolveTarget(p.explicitTarget, p.trigger, &cfg)
+		// Concurrent sessions all see the same rate limit at once: the
+		// first wrapper through the lock swaps, and without this check
+		// every other one would land on the freshly-switched, healthy
+		// account and still swap again — one pointless hop per session,
+		// burning through the whole pool. Refresh first so the verdict
+		// uses current data, then skip the swap when the live account
+		// already has room. Manual switches are never skipped.
+		swapped := true
+		var from, to store.Account
+		if p.explicitTarget == "" &&
+			(p.trigger == history.TriggerRateLimit || p.trigger == history.TriggerThreshold) {
+			_, _ = monitor.RefreshAll()
+			if acct, ok := liveAccountWithCapacity(&cfg); ok {
+				fmt.Fprintf(w, "cux: %s already has capacity (another session may have swapped) — resuming without switching\n", acct.Email)
+				from, to = acct, acct
+				swapped = false
 			}
 		}
-		if err != nil && cfg.WaitForReset && p.explicitTarget == "" &&
-			(p.trigger == history.TriggerRateLimit || p.trigger == history.TriggerThreshold) {
-			target, err = waitForReset(p.trigger, &cfg, w)
-		}
-		if err != nil {
-			fmt.Fprintf(w, "cux: %v — staying on current account\n", err)
-			return exitCode, nil
-		}
 
-		from, to, swapErr := switcher.SwitchTo(target)
-		if swapErr != nil {
-			fmt.Fprintf(w, "cux: switch failed: %v\n", swapErr)
-			return 1, swapErr
-		}
-
-		// Append swap to the history log. Best-effort — a failure
-		// here doesn't unwind the swap.
 		cwd, _ := os.Getwd()
-		toUsageCache, _ := usage.LoadCache()
-		toUsage := toUsageCache[to.Email]
-		entry := history.Entry{
-			From:        from.Email,
-			To:          to.Email,
-			Trigger:     p.trigger,
-			Reason:      p.reason,
-			SessionID:   sessionID,
-			CWD:         cwd,
-			FromUsage5h: utilizationOrZero(p.fromUsage.FiveHour),
-			FromUsage7d: utilizationOrZero(p.fromUsage.SevenDay),
-			ToUsage5h:   utilizationOrZero(toUsage.FiveHour),
-			ToUsage7d:   utilizationOrZero(toUsage.SevenDay),
-		}
-		_ = history.Append(entry)
+		if swapped {
+			target, err := resolveTarget(p.explicitTarget, p.trigger, &cfg)
+			if err != nil && cfg.WaitForReset && p.explicitTarget == "" &&
+				(p.trigger == history.TriggerRateLimit || p.trigger == history.TriggerThreshold) {
+				target, err = waitForReset(p.trigger, &cfg, w)
+			}
+			if err != nil {
+				fmt.Fprintf(w, "cux: %v — staying on current account\n", err)
+				return exitCode, nil
+			}
 
-		// Refresh both accounts' caches. The "from" entry now
-		// represents the freshest reading we have; the "to" entry
-		// will be updated again at the first Stop on the new
-		// session, but doing it here gives `cux list` correct data
-		// immediately.
-		go func(from, to string) {
-			_ = monitor.RefreshActive(from)
-			_ = monitor.RefreshActive(to)
-		}(from.Email, to.Email)
+			var swapErr error
+			from, to, swapErr = switcher.SwitchTo(target)
+			if swapErr != nil {
+				fmt.Fprintf(w, "cux: switch failed: %v\n", swapErr)
+				return 1, swapErr
+			}
+
+			// Append swap to the history log. Best-effort — a failure
+			// here doesn't unwind the swap.
+			toUsageCache, _ := usage.LoadCache()
+			toUsage := toUsageCache[to.Email]
+			entry := history.Entry{
+				From:        from.Email,
+				To:          to.Email,
+				Trigger:     p.trigger,
+				Reason:      p.reason,
+				SessionID:   sessionID,
+				CWD:         cwd,
+				FromUsage5h: utilizationOrZero(p.fromUsage.FiveHour),
+				FromUsage7d: utilizationOrZero(p.fromUsage.SevenDay),
+				ToUsage5h:   utilizationOrZero(toUsage.FiveHour),
+				ToUsage7d:   utilizationOrZero(toUsage.SevenDay),
+			}
+			_ = history.Append(entry)
+
+			// Refresh both accounts' caches. The "from" entry now
+			// represents the freshest reading we have; the "to" entry
+			// will be updated again at the first Stop on the new
+			// session, but doing it here gives `cux list` correct data
+			// immediately.
+			go func(from, to string) {
+				_ = monitor.RefreshActive(from)
+				_ = monitor.RefreshActive(to)
+			}(from.Email, to.Email)
+		}
 
 		// Update the manual-switch guard. A deliberate /switch sets the
 		// guard; a rate-limit or threshold swap clears it (necessity wins).
@@ -260,10 +276,12 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			// Only resume if at least one turn completed — an empty/just-started
 			// session has no transcript content and claude rejects --resume for it.
 			// This applies to all trigger types including manual /switch.
-			switch p.trigger {
-			case history.TriggerRateLimit:
+			switch {
+			case !swapped:
+				fmt.Fprintf(w, "cux: resuming on %s…\n", to.Email)
+			case p.trigger == history.TriggerRateLimit:
 				fmt.Fprintf(w, "cux: rate limit on %s → swapped to %s, resuming…\n", from.Email, to.Email)
-			case history.TriggerManual:
+			case p.trigger == history.TriggerManual:
 				fmt.Fprintf(w, "cux: %s → %s, resuming…\n", from.Email, to.Email)
 			default:
 				fmt.Fprintf(w, "cux: %s → %s (%s), resuming…\n", from.Email, to.Email, p.reason)
@@ -284,7 +302,11 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 		} else {
 			// No session to resume — Claude will start fresh (welcome screen).
 			// Print the switch result so the user knows which account is now active.
-			fmt.Fprintf(w, "cux: switched to %s — now active\n", to.Email)
+			if swapped {
+				fmt.Fprintf(w, "cux: switched to %s — now active\n", to.Email)
+			} else {
+				fmt.Fprintf(w, "cux: continuing on %s\n", to.Email)
+			}
 			currentArgv = argv
 		}
 	}
@@ -721,6 +743,9 @@ func isActiveHardLimited() bool {
 // even the fallback path never spins.
 const (
 	waitForResetAttempts = 4
+	// waitPollInterval is how often a sleeping waitForReset re-reads
+	// the shared cache for capacity another session may have created.
+	waitPollInterval = time.Minute
 	// resetSlack pads each sleep so we wake after the API-side window
 	// has actually rolled over, not in the same second it should.
 	resetSlack = 90 * time.Second
@@ -743,13 +768,66 @@ func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (str
 		}
 		fmt.Fprintf(w, "cux: all accounts exhausted — waiting %s for %s to reset…\n",
 			shortDuration(d), email)
-		time.Sleep(d)
+		// Sleep in slices instead of one block: a concurrent session may
+		// swap or refresh the shared cache while we wait, in which case
+		// capacity is available long before the computed reset. The
+		// probes only read local files — with no other session writing,
+		// they never fire and this degrades to the single plain sleep.
+		for d > 0 {
+			chunk := min(d, waitPollInterval)
+			time.Sleep(chunk)
+			d -= chunk
+			if acct, ok := liveAccountWithCapacity(cfg); ok {
+				fmt.Fprintf(w, "cux: %s regained capacity while waiting — resuming early\n", acct.Email)
+				return acct.Email, nil
+			}
+			if target, err := resolveTarget("", trigger, cfg); err == nil {
+				fmt.Fprintf(w, "cux: capacity appeared on %s while waiting — resuming early\n", target)
+				return target, nil
+			}
+		}
 		_, _ = monitor.RefreshAll()
 		if target, err := resolveTarget("", trigger, cfg); err == nil {
 			return target, nil
 		}
 	}
 	return "", errors.New("accounts still exhausted after waiting for resets")
+}
+
+// liveAccountWithCapacity returns the managed account currently
+// holding the live credentials, when it still has switch capacity
+// under the configured thresholds. ok is false when the live account
+// is unmanaged, has no usage data yet, or is out of room — callers
+// then proceed with a normal swap.
+func liveAccountWithCapacity(cfg *config.Config) (store.Account, bool) {
+	email, err := switcher.CurrentLiveEmail()
+	if err != nil || email == "" {
+		return store.Account{}, false
+	}
+	state, err := store.Load()
+	if err != nil {
+		return store.Account{}, false
+	}
+	slot := state.FindByEmail(email)
+	if slot == 0 {
+		return store.Account{}, false
+	}
+	acct := state.Accounts[slot]
+	cache, _ := usage.LoadCache()
+	u, ok := cachedUsage(cache, acct.CacheKey(), acct.Email)
+	if !ok || u.TokenExpired {
+		return store.Account{}, false
+	}
+	// accountHasSwitchCapacity looks the entry up by one key only;
+	// hand it whichever key actually holds the data.
+	key := acct.CacheKey()
+	if _, exists := cache[key]; !exists {
+		key = acct.Email
+	}
+	if !accountHasSwitchCapacity(cache, key, cfg) {
+		return store.Account{}, false
+	}
+	return acct, true
 }
 
 // nextAvailability returns the earliest instant any account becomes

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -808,11 +808,27 @@ func liveAccountWithCapacity(cfg *config.Config) (store.Account, bool) {
 	if err != nil {
 		return store.Account{}, false
 	}
-	slot := state.FindByEmail(email)
-	if slot == 0 {
-		return store.Account{}, false
+	// Find the seat holding the live credentials by cache key first —
+	// emails are not unique (the same address can hold a personal
+	// subscription and one seat per org); email is the legacy fallback.
+	liveKey, _ := switcher.CurrentLiveCacheKey()
+	var acct store.Account
+	found := false
+	if liveKey != "" && liveKey != email {
+		for _, a := range state.Accounts {
+			if a.CacheKey() == liveKey {
+				acct, found = a, true
+				break
+			}
+		}
 	}
-	acct := state.Accounts[slot]
+	if !found {
+		slot := state.FindByEmail(email)
+		if slot == 0 {
+			return store.Account{}, false
+		}
+		acct = state.Accounts[slot]
+	}
 	cache, _ := usage.LoadCache()
 	u, ok := cachedUsage(cache, acct.CacheKey(), acct.Email)
 	if !ok || u.TokenExpired {


### PR DESCRIPTION
Fixes #21.

## Problem

N concurrent cux sessions all see the same rate limit at once. Swaps are lock-serialised (no corruption), but each wrapper resolves its target against the **current live account** — which the first session through the lock just switched to a healthy one. The strategy always excludes current from its candidates and the rate-limit path never re-checks whether current is still limited, so every subsequent session hops one account further: one pointless swap per session, draining the pool.

## Change

- **Skip the swap when live already has capacity.** Before resolving a rate-limit/threshold target: `RefreshAll`, then `liveAccountWithCapacity` — live email → managed account → cached usage → `accountHasSwitchCapacity`. If it has room (another session swapped, or the window reset), print why, skip `SwitchTo`/history, and resume in place; the relaunch reads live credentials, so all sessions converge onto the same healthy account. Conservative gates: unmanaged live account, missing usage data, or an expired token never skip. Manual switches (`/switch`, explicit targets) never skip. This mirrors the recovery re-check `handleAutoSwitchPrompt` already does on the hook side.
- **`waitForReset` wakes early on concurrent activity.** Sleeps in 1-minute slices; between slices it probes the shared cache (`liveAccountWithCapacity` + a cache-only `resolveTarget`). A concurrent session's swap or refresh makes capacity visible long before the computed reset. With no other session writing, the probes read unchanged local files and never fire — single-session behavior is exactly the old single sleep.
- The now-redundant refresh-and-retry inside the resolve path folded into the upfront refresh.

## Tested on macOS 15 (arm64)

- New `TestLiveAccountWithCapacity` (5 cases: healthy-live skip, exhausted live, no data, unmanaged live, expired token) using the #16 isolation env — no real keychain or ~/.cux touched
- `go vet ./...` clean, `gofmt` clean, full `go test ./...` passes (12 packages)

Note: touches the same `Run` region as #19 (resume fallback) — whichever lands first, I'm happy to update the other.