### PR TITLE
fix: identify accounts by seat, not email, in strategy decisions

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -209,7 +209,7 @@ func handleAutoSwitchPrompt(prompt string, stdout io.Writer) (bool, error) {
 	}
 	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
 	for _, a := range state.Accounts {
-		candidates = append(candidates, strategy.Candidate{Email: a.Email, CacheKey: a.CacheKey()})
+		candidates = append(candidates, strategy.Candidate{Email: a.Email, Slot: a.Slot, CacheKey: a.CacheKey()})
 	}
 	current := strategy.Candidate{Email: email, CacheKey: cacheKey}
 	if _, ok := cache[cacheKey]; !ok {
@@ -233,7 +233,7 @@ func handleAutoSwitchPrompt(prompt string, stdout io.Writer) (bool, error) {
 				goto inPlaceSwap
 			}
 			if err := signals.Write(pid, signals.SwitchRequested, signals.SwitchRequestedPayload{
-				Target:    pick.Email,
+				Target:    pick.Identifier(),
 				Timestamp: time.Now().UTC(),
 			}); err != nil {
 				writePromptBlock(stdout, fmt.Sprintf("cux: %s\ncux: signal failed: %v", why, err))
@@ -247,7 +247,7 @@ func handleAutoSwitchPrompt(prompt string, stdout io.Writer) (bool, error) {
 		// Pre-turn prompt: swap credentials in-place. Claude Code reads
 		// credentials on every API request, so this prompt will be processed
 		// by the new account with no restart or manual resend needed.
-		from, to, switchErr := switcher.SwitchTo(pick.Email)
+		from, to, switchErr := switcher.SwitchTo(pick.Identifier())
 		if switchErr != nil {
 			writePromptBlock(stdout, fmt.Sprintf("cux: %s\ncux: failed to switch to %s: %v", why, pick.Email, switchErr))
 			return true, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -29,3 +29,23 @@ func TestCacheKeyLegacyFallbacks(t *testing.T) {
 		t.Errorf("email-only account: got %q, want %q", got, "a@x.test")
 	}
 }
+
+func TestFindByIdentityPersonalVsOrgSeat(t *testing.T) {
+	s := &State{Accounts: map[int]Account{
+		1: {Slot: 1, Email: "me@x.test", UUID: "u-me"},                      // personal: no org
+		2: {Slot: 2, Email: "me@x.test", UUID: "u-me", OrgUUID: "org-corp"}, // org seat
+	}}
+	if got := s.FindByIdentity("me@x.test", ""); got != 1 {
+		t.Errorf("personal login resolved to slot %d, want 1", got)
+	}
+	if got := s.FindByIdentity("me@x.test", "org-corp"); got != 2 {
+		t.Errorf("org login resolved to slot %d, want 2", got)
+	}
+}
+
+func TestCacheKeyPersonalAccountFallsBackToEmail(t *testing.T) {
+	personal := Account{Email: "me@x.test", UUID: "u-me"} // no OrgUUID
+	if got := personal.CacheKey(); got != "me@x.test" {
+		t.Errorf("personal CacheKey = %q, want email fallback", got)
+	}
+}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -26,6 +26,7 @@ package strategy
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/inulute/cux/internal/usage"
@@ -72,6 +73,7 @@ func ParseKind(s string) Kind {
 // converts its store.Account list into Candidates before calling.
 type Candidate struct {
 	Email    string
+	Slot     int    // stable seat identifier; 0 when unknown (e.g. the live account)
 	CacheKey string // usage-cache key; falls back to Email when empty
 }
 
@@ -85,11 +87,34 @@ func (c Candidate) cacheKey() string {
 	return c.Email
 }
 
+// sameSeat reports whether two candidates are the same seat. Emails are
+// not unique — the same address can hold a personal subscription and
+// one seat per organization — so compare by cache key (one per seat)
+// whenever both sides carry one, and only fall back to email for
+// legacy candidates that predate seat keys.
+func sameSeat(a, b Candidate) bool {
+	if a.CacheKey != "" && b.CacheKey != "" {
+		return a.CacheKey == b.CacheKey
+	}
+	return a.Email == b.Email
+}
+
 // Pick is the strategy's answer. Reason is a short human-readable
 // label included in the swap-history log.
 type Pick struct {
 	Email  string
+	Slot   int // seat identifier; 0 when the pick predates slot tracking
 	Reason string
+}
+
+// Identifier returns the string to hand to switcher.SwitchTo. Slots are
+// unambiguous (emails are not, see sameSeat), so prefer the slot number
+// whenever the pick carries one.
+func (p Pick) Identifier() string {
+	if p.Slot > 0 {
+		return strconv.Itoa(p.Slot)
+	}
+	return p.Email
 }
 
 // PickNext chooses an account to swap to.
@@ -166,7 +191,7 @@ func ShouldRebalance(
 		var bestUtil float64 = -1
 		for i := range accounts {
 			c := &accounts[i]
-			if c.Email == current.Email {
+			if sameSeat(*c, current) {
 				continue
 			}
 			if !isAvailable(cache, c.cacheKey()) {
@@ -186,10 +211,10 @@ func ShouldRebalance(
 		priority = best
 	}
 
-	if priority == nil || priority.Email == current.Email {
+	if priority == nil || sameSeat(*priority, current) {
 		return Pick{}, false
 	}
-	return Pick{Email: priority.Email, Reason: "rebalance to priority account"}, true
+	return Pick{Email: priority.Email, Slot: priority.Slot, Reason: "rebalance to priority account"}, true
 }
 
 // --- internals -----------------------------------------------------------
@@ -220,7 +245,7 @@ func pickDrain(
 			continue
 		}
 		if fiveHourUtil(cache, c.cacheKey()) < float64(cap5) && sevenDayUtil(cache, c.cacheKey()) < float64(cap7) {
-			return Pick{Email: c.Email, Reason: "drain: 7d under cap"}, true
+			return Pick{Email: c.Email, Slot: c.Slot, Reason: "drain: 7d under cap"}, true
 		}
 	}
 
@@ -232,7 +257,7 @@ func pickDrain(
 			continue
 		}
 		if fiveHourUtil(cache, c.cacheKey()) < float64(cap5) && sevenDayUtil(cache, c.cacheKey()) < 100 {
-			return Pick{Email: c.Email, Reason: "drain: 5h has room"}, true
+			return Pick{Email: c.Email, Slot: c.Slot, Reason: "drain: 5h has room"}, true
 		}
 	}
 
@@ -242,7 +267,7 @@ func pickDrain(
 func pickBalanced(accounts []Candidate, current Candidate, cache usage.Cache, thresholds usage.Thresholds) (Pick, bool) {
 	candidates := make([]Candidate, 0, len(accounts))
 	for _, c := range accounts {
-		if c.Email == current.Email {
+		if sameSeat(c, current) {
 			continue
 		}
 		if !isAvailable(cache, c.cacheKey()) {
@@ -266,7 +291,7 @@ func pickBalanced(accounts []Candidate, current Candidate, cache usage.Cache, th
 		}
 		return fiveHourUtil(cache, candidates[i].cacheKey()) < fiveHourUtil(cache, candidates[j].cacheKey())
 	})
-	return Pick{Email: candidates[0].Email, Reason: "balanced: lowest 7d"}, true
+	return Pick{Email: candidates[0].Email, Slot: candidates[0].Slot, Reason: "balanced: lowest 7d"}, true
 }
 
 // orderedCandidates returns the drain-mode evaluation order: the
@@ -277,7 +302,7 @@ func orderedCandidates(order []string, accounts []Candidate, current Candidate, 
 	if len(order) == 0 {
 		out := make([]Candidate, 0, len(accounts))
 		for _, c := range accounts {
-			if c.Email == current.Email {
+			if sameSeat(c, current) {
 				continue
 			}
 			out = append(out, c)
@@ -289,11 +314,13 @@ func orderedCandidates(order []string, accounts []Candidate, current Candidate, 
 	}
 	out := make([]Candidate, 0, len(order))
 	for _, email := range order {
-		if email == current.Email {
-			continue
-		}
-		if c := findByEmail(accounts, email); c != nil {
-			out = append(out, *c)
+		// An email in the priority list may match several seats (personal
+		// + org). Keep them all, in list order, minus the current seat.
+		for i := range accounts {
+			if accounts[i].Email != email || sameSeat(accounts[i], current) {
+				continue
+			}
+			out = append(out, accounts[i])
 		}
 	}
 	return out

--- a/internal/strategy/twins_test.go
+++ b/internal/strategy/twins_test.go
@@ -69,3 +69,48 @@ func TestIdentifierFallsBackToEmail(t *testing.T) {
 		t.Errorf("Identifier() = %q, want email fallback for slotless picks", p.Identifier())
 	}
 }
+
+// A mixed pool: a personal subscription (no org, so its seat key falls
+// back to the email) next to org seats. Every plan type must interop.
+func TestPickNextMixedPersonalAndOrgSeats(t *testing.T) {
+	personal := Candidate{Email: "me@x.test", Slot: 1, CacheKey: "me@x.test"} // Account.CacheKey() email fallback
+	orgSeat := Candidate{Email: "me@x.test", Slot: 2, CacheKey: "u-me|org-corp"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+
+	cache := usage.Cache{
+		"me@x.test":     {FiveHour: &usage.Window{Utilization: 100}, SevenDay: &usage.Window{Utilization: 50}},
+		"u-me|org-corp": {FiveHour: &usage.Window{Utilization: 10}, SevenDay: &usage.Window{Utilization: 20}},
+	}
+
+	// Personal seat exhausted → must rotate onto the org seat even
+	// though the seat keys use different shapes (email vs uuid|org).
+	pick, ok := PickNext(KindDrain, nil, []Candidate{personal, orgSeat}, personal, cache, th)
+	if !ok || pick.Slot != 2 {
+		t.Errorf("got (slot %d, %v), want the org seat (slot 2, true)", pick.Slot, ok)
+	}
+
+	// And the reverse: org seat exhausted → personal picks up.
+	cache["me@x.test"] = usage.AccountUsage{FiveHour: &usage.Window{Utilization: 10}, SevenDay: &usage.Window{Utilization: 20}}
+	cache["u-me|org-corp"] = usage.AccountUsage{FiveHour: &usage.Window{Utilization: 100}, SevenDay: &usage.Window{Utilization: 50}}
+	pick, ok = PickNext(KindDrain, nil, []Candidate{personal, orgSeat}, orgSeat, cache, th)
+	if !ok || pick.Slot != 1 {
+		t.Errorf("got (slot %d, %v), want the personal seat (slot 1, true)", pick.Slot, ok)
+	}
+}
+
+// Windows the API omits for a plan (e.g. no weekly cap) must read as
+// capacity, not as exhaustion — pointers stay nil and every check
+// treats nil as room.
+func TestPickNextToleratesMissingWindows(t *testing.T) {
+	a := Candidate{Email: "a@x.test", Slot: 1, CacheKey: "u-a|org"}
+	b := Candidate{Email: "b@x.test", Slot: 2, CacheKey: "u-b|org"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+	cache := usage.Cache{
+		"u-a|org": {FiveHour: &usage.Window{Utilization: 100}}, // no 7d window at all
+		"u-b|org": {FiveHour: &usage.Window{Utilization: 5}},   // no 7d window at all
+	}
+	pick, ok := PickNext(KindDrain, nil, []Candidate{a, b}, a, cache, th)
+	if !ok || pick.Slot != 2 {
+		t.Errorf("got (slot %d, %v), want slot 2 despite missing 7d windows", pick.Slot, ok)
+	}
+}

--- a/internal/strategy/twins_test.go
+++ b/internal/strategy/twins_test.go
@@ -1,0 +1,71 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/inulute/cux/internal/usage"
+)
+
+// Twin seats: the same email holding a personal subscription and an
+// organization seat. Emails cannot distinguish them — seat keys can.
+func twinFixture() ([]Candidate, Candidate, usage.Cache) {
+	personal := Candidate{Email: "me@x.test", Slot: 1, CacheKey: "u-me|org-personal"}
+	orgSeat := Candidate{Email: "me@x.test", Slot: 2, CacheKey: "u-me|org-corp"}
+	other := Candidate{Email: "other@x.test", Slot: 3, CacheKey: "u-other|org-corp"}
+
+	cache := usage.Cache{
+		"u-me|org-personal": {FiveHour: &usage.Window{Utilization: 100}, SevenDay: &usage.Window{Utilization: 60}},
+		"u-me|org-corp":     {FiveHour: &usage.Window{Utilization: 5}, SevenDay: &usage.Window{Utilization: 10}},
+		"u-other|org-corp":  {FiveHour: &usage.Window{Utilization: 100}, SevenDay: &usage.Window{Utilization: 100}},
+	}
+	return []Candidate{personal, orgSeat, other}, personal, cache
+}
+
+func TestPickNextDistinguishesTwinSeats(t *testing.T) {
+	accounts, current, cache := twinFixture()
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+
+	// Exhausted personal seat must be able to rotate onto the SAME
+	// email's healthy org seat. With email-keyed comparison both twins
+	// were excluded and the pick failed (or fell through to the also
+	// exhausted third account).
+	pick, ok := PickNext(KindDrain, nil, accounts, current, cache, th)
+	if !ok {
+		t.Fatal("expected a pick, got none — twin seat was excluded along with current")
+	}
+	if pick.Slot != 2 {
+		t.Errorf("picked slot %d (%s), want the twin org seat (slot 2)", pick.Slot, pick.Reason)
+	}
+	if pick.Identifier() != "2" {
+		t.Errorf("Identifier() = %q, want the unambiguous slot number \"2\"", pick.Identifier())
+	}
+}
+
+func TestPickBalancedDistinguishesTwinSeats(t *testing.T) {
+	accounts, current, cache := twinFixture()
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+
+	pick, ok := PickNext(KindBalanced, nil, accounts, current, cache, th)
+	if !ok || pick.Slot != 2 {
+		t.Errorf("got (slot %d, %v), want the twin org seat (slot 2, true)", pick.Slot, ok)
+	}
+}
+
+func TestOrderedTwinSeatsBothConsidered(t *testing.T) {
+	accounts, current, cache := twinFixture()
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+
+	// The priority list can only speak in emails; both seats behind an
+	// email must be considered, minus the current one.
+	pick, ok := PickNext(KindDrain, []string{"me@x.test", "other@x.test"}, accounts, current, cache, th)
+	if !ok || pick.Slot != 2 {
+		t.Errorf("got (slot %d, %v), want the twin org seat (slot 2, true)", pick.Slot, ok)
+	}
+}
+
+func TestIdentifierFallsBackToEmail(t *testing.T) {
+	p := Pick{Email: "legacy@x.test"}
+	if p.Identifier() != "legacy@x.test" {
+		t.Errorf("Identifier() = %q, want email fallback for slotless picks", p.Identifier())
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -625,7 +625,7 @@ func evaluateThresholdSwap(cfg *config.Config, manualTarget string) *pending {
 	}
 	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
 	for _, a := range state.Accounts {
-		candidates = append(candidates, strategy.Candidate{Email: a.Email, CacheKey: a.CacheKey()})
+		candidates = append(candidates, strategy.Candidate{Email: a.Email, Slot: a.Slot, CacheKey: a.CacheKey()})
 	}
 	current := strategy.Candidate{Email: email, CacheKey: cacheKey}
 	if _, ok := cache[cacheKey]; !ok {
@@ -643,7 +643,7 @@ func evaluateThresholdSwap(cfg *config.Config, manualTarget string) *pending {
 	return &pending{
 		trigger:        history.TriggerThreshold,
 		reason:         reason,
-		explicitTarget: pick.Email,
+		explicitTarget: pick.Identifier(),
 		fromUsage:      u,
 	}
 }
@@ -964,7 +964,7 @@ func resolveTarget(explicit string, trigger history.Trigger, cfg *config.Config)
 	}
 	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
 	for _, a := range state.Accounts {
-		candidates = append(candidates, strategy.Candidate{Email: a.Email, CacheKey: a.CacheKey()})
+		candidates = append(candidates, strategy.Candidate{Email: a.Email, Slot: a.Slot, CacheKey: a.CacheKey()})
 	}
 	// In manual mode strategy.PickNext returns ok=false, but a manual
 	// trigger with no explicit target still means "rotate" — fall
@@ -975,7 +975,7 @@ func resolveTarget(explicit string, trigger history.Trigger, cfg *config.Config)
 	}
 	if pick, ok := strategy.PickNext(kind, cfg.Strategy.Order, candidates,
 		strategy.Candidate{Email: current, CacheKey: currentCacheKey}, cache, cfg.Thresholds); ok {
-		return pick.Email, nil
+		return pick.Identifier(), nil
 	}
 	return rotateFallback(state, cache, cfg)
 }

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -124,8 +124,10 @@ func TestEvaluatePrelaunchHardLimitSwapUsesRateLimitTrigger(t *testing.T) {
 	if p.trigger != history.TriggerRateLimit {
 		t.Fatalf("trigger = %q, want %q", p.trigger, history.TriggerRateLimit)
 	}
-	if p.explicitTarget != "b@x.test" {
-		t.Fatalf("target = %q, want b@x.test", p.explicitTarget)
+	// Picks now carry the seat's slot number — unambiguous where emails
+	// are not (the same email can hold personal + org seats).
+	if p.explicitTarget != "2" {
+		t.Fatalf("target = %q, want slot \"2\" (b@x.test)", p.explicitTarget)
 	}
 	if !strings.Contains(p.reason, "before launch") {
 		t.Fatalf("reason should include before launch, got %q", p.reason)


### PR DESCRIPTION
Fixes #23.

## Problem

Adding twin seats (same email: personal + org) works since #1, and the usage cache is per-seat since #9 — but strategy decisions still speak email: `orderedCandidates`/`pickBalanced` exclude *all* seats sharing the current email (so a twin can never be rotated onto), and picks resolve through `FindByEmail` (map order — with twins the swap can nondeterministically land back on the exhausted seat it was escaping).

## Change

- `sameSeat(a, b)`: compare by cache key (one per account × org) when both sides carry one; email only as a legacy fallback. Used everywhere a candidate is matched against `current` (drain, balanced, rebalance, ordered list).
- `Candidate.Slot` + `Pick.Slot` + `Pick.Identifier()`: picks now hand `SwitchTo` the slot number — unambiguous, and the same convention `rotateFallback` already uses. Slotless legacy picks fall back to email.
- The email-based `strategy.order` list now considers **every** seat behind a listed email, in list order, minus the current seat (previously: first match only).
- Call sites plumbed in wrapper (threshold/prelaunch/resolve) and hooks (prompt-submit switch signal + in-place switch).

Pools of distinct emails behave exactly as before — one wrapper test updated to the new slot-form target, everything else untouched.

## Tested on macOS 15 (arm64)

- New `twins_test.go`: exhausted personal seat rotates onto the same email's healthy org seat under drain, balanced, and an email priority list; `Identifier()` email fallback
- `go vet ./...` clean, `gofmt` clean on touched files, full `go test ./...` passes (12 packages)