### PR TITLE
feat: prefer accounts with model-window headroom when picking a swap target

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,13 @@ Config file: `~/.config/cux/config.json` (XDG-aware).
 - **manual** — Never swap automatically. `/switch` and `cux switch`
   still work.
 
+Both automatic strategies also prefer accounts whose model-specific
+weekly windows (Opus/Sonnet, reported on some plans) still have room.
+A model-capped account is never made ineligible — cux cannot know
+which model the session will ask for next — it just sorts behind
+model-clear candidates, so a heavy-Opus session is not swapped onto a
+seat that would rate-limit its very next call.
+
 ## Swap history
 
 ```text

--- a/internal/strategy/modelwindows_test.go
+++ b/internal/strategy/modelwindows_test.go
@@ -1,0 +1,133 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/inulute/cux/internal/usage"
+)
+
+func mw(five, seven float64, opus *float64) usage.AccountUsage {
+	u := usage.AccountUsage{
+		FiveHour: &usage.Window{Utilization: five},
+		SevenDay: &usage.Window{Utilization: seven},
+	}
+	if opus != nil {
+		u.SevenDayOpus = &usage.Window{Utilization: *opus}
+	}
+	return u
+}
+
+func pct(v float64) *float64 { return &v }
+
+func TestDrainPrefersModelClearCandidate(t *testing.T) {
+	// b ranks first by 7d-drain order but its Opus window is capped;
+	// c is model-clear and must win despite ranking later.
+	a := Candidate{Email: "a@x.test", CacheKey: "a"}
+	b := Candidate{Email: "b@x.test", CacheKey: "b"}
+	c := Candidate{Email: "c@x.test", CacheKey: "c"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+	cache := usage.Cache{
+		"a": mw(100, 80, nil),     // current, exhausted
+		"b": mw(10, 60, pct(100)), // healthiest overall but Opus-capped
+		"c": mw(10, 30, nil),      // model-clear
+	}
+	pick, ok := PickNext(KindDrain, nil, []Candidate{a, b, c}, a, cache, th)
+	if !ok || pick.Email != "c@x.test" {
+		t.Errorf("got (%q, %v), want the model-clear c@x.test", pick.Email, ok)
+	}
+}
+
+func TestDrainFallsBackWhenAllModelCapped(t *testing.T) {
+	// Every candidate is model-capped → the second sweep must restore
+	// today's pick instead of stranding the pool.
+	a := Candidate{Email: "a@x.test", CacheKey: "a"}
+	b := Candidate{Email: "b@x.test", CacheKey: "b"}
+	c := Candidate{Email: "c@x.test", CacheKey: "c"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+	cache := usage.Cache{
+		"a": mw(100, 80, pct(100)),
+		"b": mw(10, 60, pct(100)),
+		"c": mw(20, 30, pct(100)),
+	}
+	pick, ok := PickNext(KindDrain, nil, []Candidate{a, b, c}, a, cache, th)
+	if !ok {
+		t.Fatal("expected a fallback pick, pool must never be stranded by the preference")
+	}
+	if pick.Email != "b@x.test" {
+		t.Errorf("fallback picked %q, want b@x.test (today's drain order)", pick.Email)
+	}
+}
+
+func TestDrainUnchangedWhenModelWindowsAbsent(t *testing.T) {
+	// Plans that do not report model windows (nil) must behave exactly
+	// as before the preference existed.
+	a := Candidate{Email: "a@x.test", CacheKey: "a"}
+	b := Candidate{Email: "b@x.test", CacheKey: "b"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+	cache := usage.Cache{
+		"a": mw(100, 80, nil),
+		"b": mw(10, 60, nil),
+	}
+	pick, ok := PickNext(KindDrain, nil, []Candidate{a, b}, a, cache, th)
+	if !ok || pick.Email != "b@x.test" {
+		t.Errorf("got (%q, %v), want b@x.test unchanged", pick.Email, ok)
+	}
+}
+
+func TestBalancedSortsModelCappedLastButEligible(t *testing.T) {
+	a := Candidate{Email: "a@x.test", CacheKey: "a"}
+	b := Candidate{Email: "b@x.test", CacheKey: "b"}
+	c := Candidate{Email: "c@x.test", CacheKey: "c"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+	cache := usage.Cache{
+		"a": mw(100, 80, nil),    // current
+		"b": mw(5, 10, pct(100)), // lowest 7d but Opus-capped
+		"c": mw(5, 40, nil),      // model-clear, higher 7d
+	}
+	pick, ok := PickNext(KindBalanced, nil, []Candidate{a, b, c}, a, cache, th)
+	if !ok || pick.Email != "c@x.test" {
+		t.Errorf("got (%q, %v), want model-clear c@x.test first", pick.Email, ok)
+	}
+
+	// b alone must still be pickable — capped means deprioritised, not
+	// ineligible.
+	pick, ok = PickNext(KindBalanced, nil, []Candidate{a, b}, a, cache, th)
+	if !ok || pick.Email != "b@x.test" {
+		t.Errorf("got (%q, %v), want b@x.test as the only candidate", pick.Email, ok)
+	}
+}
+
+func TestRebalanceRefusesModelCappedPriority(t *testing.T) {
+	priority := Candidate{Email: "prio@x.test", CacheKey: "p"}
+	temp := Candidate{Email: "temp@x.test", CacheKey: "t"}
+	th := usage.Thresholds{FiveHour: 100, SevenDay: 100}
+	cache := usage.Cache{
+		"p": mw(5, 10, pct(100)), // healthy overall, Opus-capped
+		"t": mw(20, 30, nil),
+	}
+	// Rebalance is proactive: hopping onto a model-capped seat trades a
+	// working account for an instant rate limit and a bounce back.
+	if pick, ok := ShouldRebalance(KindDrain, []string{"prio@x.test"},
+		[]Candidate{priority, temp}, temp, cache, th); ok {
+		t.Errorf("expected no rebalance onto model-capped priority, got %q", pick.Email)
+	}
+
+	// Once the model window resets, the rebalance resumes.
+	cache["p"] = mw(5, 10, pct(40))
+	if pick, ok := ShouldRebalance(KindDrain, []string{"prio@x.test"},
+		[]Candidate{priority, temp}, temp, cache, th); !ok || pick.Email != "prio@x.test" {
+		t.Errorf("got (%q, %v), want rebalance to prio@x.test", pick.Email, ok)
+	}
+}
+
+func TestModelCappedReadsSonnetWindowToo(t *testing.T) {
+	u := mw(5, 10, nil)
+	u.SevenDaySonnet = &usage.Window{Utilization: 100}
+	cache := usage.Cache{"k": u}
+	if !modelCapped(cache, "k") {
+		t.Error("sonnet window at 100%% must count as model-capped")
+	}
+	if modelCapped(cache, "missing") {
+		t.Error("missing cache entry must not read as capped")
+	}
+}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -156,6 +156,13 @@ func ShouldRebalance(
 					continue
 				}
 			}
+			// Never rebalance ONTO a model-capped account: the hop is
+			// proactive, and landing a heavy-Opus session on a capped
+			// seat trades a working account for an instant rate limit —
+			// and a bounce right back at the next Stop.
+			if modelCapped(cache, c.cacheKey()) {
+				continue
+			}
 			priority = c
 			break
 		}
@@ -176,6 +183,9 @@ func ShouldRebalance(
 				if over, _ := usage.IsOverThreshold(u, thresholds); over {
 					continue
 				}
+			}
+			if modelCapped(cache, c.cacheKey()) {
+				continue
 			}
 			u := sevenDayUtil(cache, c.cacheKey())
 			if u > bestUtil {
@@ -215,24 +225,42 @@ func pickDrain(
 	if cap5 == 0 || cap5 == 100 {
 		cap5 = 90
 	}
-	for _, c := range ordered {
-		if !isAvailable(cache, c.cacheKey()) {
-			continue
-		}
-		if fiveHourUtil(cache, c.cacheKey()) < float64(cap5) && sevenDayUtil(cache, c.cacheKey()) < float64(cap7) {
-			return Pick{Email: c.Email, Reason: "drain: 7d under cap"}, true
+	// Each pass runs twice: first over candidates whose model-specific
+	// weekly windows (Opus/Sonnet) still have room, then over the rest.
+	// Model windows never make an account ineligible — cux cannot know
+	// which model the wrapped session will ask for next — but a
+	// model-capped account is a worse first choice: a heavy-Opus
+	// session swapped onto it rate-limits on its next call. When every
+	// candidate is model-capped the second sweep restores today's pick,
+	// so a pool is never stranded by this preference.
+	for _, preferModelClear := range []bool{true, false} {
+		for _, c := range ordered {
+			if preferModelClear && modelCapped(cache, c.cacheKey()) {
+				continue
+			}
+			if !isAvailable(cache, c.cacheKey()) {
+				continue
+			}
+			if fiveHourUtil(cache, c.cacheKey()) < float64(cap5) && sevenDayUtil(cache, c.cacheKey()) < float64(cap7) {
+				return Pick{Email: c.Email, Reason: "drain: 7d under cap"}, true
+			}
 		}
 	}
 
 	// Pass 2: 5h has any room — but never pick a 7D-hard-full account.
 	// A 7D-at-100% account has no recoverable capacity in this window
 	// regardless of 5h utilisation.
-	for _, c := range ordered {
-		if !isAvailable(cache, c.cacheKey()) {
-			continue
-		}
-		if fiveHourUtil(cache, c.cacheKey()) < float64(cap5) && sevenDayUtil(cache, c.cacheKey()) < 100 {
-			return Pick{Email: c.Email, Reason: "drain: 5h has room"}, true
+	for _, preferModelClear := range []bool{true, false} {
+		for _, c := range ordered {
+			if preferModelClear && modelCapped(cache, c.cacheKey()) {
+				continue
+			}
+			if !isAvailable(cache, c.cacheKey()) {
+				continue
+			}
+			if fiveHourUtil(cache, c.cacheKey()) < float64(cap5) && sevenDayUtil(cache, c.cacheKey()) < 100 {
+				return Pick{Email: c.Email, Reason: "drain: 5h has room"}, true
+			}
 		}
 	}
 
@@ -260,6 +288,12 @@ func pickBalanced(accounts []Candidate, current Candidate, cache usage.Cache, th
 		return Pick{}, false
 	}
 	sort.SliceStable(candidates, func(i, j int) bool {
+		// Model-capped accounts stay eligible but sort last — see the
+		// rationale on modelCapped.
+		mi, mj := modelCapped(cache, candidates[i].cacheKey()), modelCapped(cache, candidates[j].cacheKey())
+		if mi != mj {
+			return !mi
+		}
 		ai, bi := sevenDayUtil(cache, candidates[i].cacheKey()), sevenDayUtil(cache, candidates[j].cacheKey())
 		if ai != bi {
 			return ai < bi
@@ -297,6 +331,24 @@ func orderedCandidates(order []string, accounts []Candidate, current Candidate, 
 		}
 	}
 	return out
+}
+
+// modelCapped reports whether any model-specific weekly window
+// (Opus/Sonnet) sits at its hard cap. Only >=100 counts: user
+// thresholds express intent about the account-wide windows, not the
+// per-model ones, and a model window the plan does not report stays
+// nil — which reads as room, like every other missing window.
+func modelCapped(cache usage.Cache, key string) bool {
+	u, ok := cache[key]
+	if !ok {
+		return false
+	}
+	for _, w := range []*usage.Window{u.SevenDayOpus, u.SevenDaySonnet} {
+		if w != nil && w.Utilization >= 100 {
+			return true
+		}
+	}
+	return false
 }
 
 func isAvailable(cache usage.Cache, email string) bool {


### PR DESCRIPTION
Implements #25, direction (2) — preference, never an eligibility gate.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Some candidates model-capped, others clear | Drain/balanced could pick a capped account → instant rate limit on the next same-model call → extra hop | Model-clear candidates picked first; capped ones remain fallback |
| **All** candidates model-capped | Pick per drain/balanced order | **Identical pick** — second sweep restores today's exact behavior, pool never stranded |
| Plan reports no model windows (nil — e.g. our Team org) | n/a | **Bit-for-bit identical** to today (nil reads as room, like every missing window) |
| Model window high but <100 (e.g. 95%) | Ignored | Still ignored — only ≥100 counts; user thresholds express intent about account-wide windows, not per-model ones |
| Rebalance-back onto a model-capped priority seat | Hop → next same-model call rate-limits → swap away → bounce back at next Stop (oscillation) | Rebalance skipped until the model window resets — the one place capped means *skip*, because the hop is proactive and trades a working account for an instant 429 |
| Only candidate is model-capped (balanced) | Picked | Still picked — deprioritised, not ineligible |

## Change

- `modelCapped(cache, key)`: any of `seven_day_opus` / `seven_day_sonnet` at ≥100.
- **drain**: each of the two existing passes runs twice — model-clear candidates first, everyone second. Pass semantics untouched.
- **balanced**: `modelCapped` prepended to the sort key (capped sorts last), eligibility filters untouched.
- **rebalance**: both branches (priority list and auto-order) skip model-capped targets.
- README: one paragraph under *Strategies*.

## Tested on macOS 15 (arm64)

- New `modelwindows_test.go`, 6 tests covering every row of the matrix above (incl. the all-capped fallback, nil-window regression, Sonnet window, and the rebalance oscillation case)
- All 24 existing strategy tests pass unchanged — the no-model-window regression guarantee
- `go vet ./...` clean, `gofmt` clean, full `go test ./...` passes (12 packages)