### PR TITLE
feat: project pools — scope the account pool per directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,38 @@ Config file: `~/.config/cux/config.json` (XDG-aware).
 - **manual** — Never swap automatically. `/switch` and `cux switch`
   still work.
 
+## Projects
+
+A machine that hosts several codebases often wants them on different
+seats — one client's work billed to their org, a personal side project
+kept off the company pool — while related projects share accounts.
+Projects bind a directory to a subset of seats:
+
+```bash
+cux project create clientwork --dir ~/code/client
+cux project assign clientwork 1 2        # seats by slot, email, or alias
+cux project create side --dir ~/code/side
+cux project assign side 2 3              # seat 2 is shared between both
+cux project list --refresh               # projects + live usage per seat
+cux project unassign side 3
+cux project remove side                  # unbind only; accounts untouched
+```
+
+When cux starts, the working directory picks the project (longest,
+path-boundary-aware match — nested projects work) and every automatic
+decision draws from that project's seats only: threshold and
+rate-limit swaps, rotation, and `wait_for_reset`'s availability math.
+
+- **No projects, or an unclaimed directory** → the full pool. Existing
+  setups behave exactly as before.
+- **A project with no seats assigned yet** → the full pool, until you
+  assign some.
+- **Explicit targets are never restricted** — `/switch <seat>` and
+  `cux switch <seat>` go wherever you point them; a human naming a
+  seat outranks the project boundary.
+- Removing an account (`cux remove`) also removes it from every
+  project pool.
+
 ## Swap history
 
 ```text

--- a/cmd/cux/main.go
+++ b/cmd/cux/main.go
@@ -64,6 +64,7 @@ const (
 // to the real claude binary via the wrapper.
 var knownSubcommands = map[string]bool{
 	"add":             true,
+	"project":         true,
 	"alias":           true,
 	"list":            true,
 	"ls":              true,
@@ -117,6 +118,8 @@ func main() {
 		cmdRemove(rest)
 	case "alias":
 		cmdAlias(rest)
+	case "project":
+		cmdProject(rest)
 	case "status":
 		cmdStatus(rest)
 	case "support":
@@ -272,6 +275,188 @@ func cmdRemove(args []string) {
 //
 //	cux alias <slot|email|alias> <new-alias>   — set alias
 //	cux alias <slot|email|alias> --clear       — remove alias
+// --- Project subcommands ---------------------------------------------------
+
+func cmdProject(args []string) {
+	if len(args) == 0 {
+		printProjectUsage()
+		os.Exit(2)
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "create":
+		cmdProjectCreate(rest)
+	case "assign":
+		cmdProjectMutate(rest, true)
+	case "unassign":
+		cmdProjectMutate(rest, false)
+	case "list", "ls":
+		cmdProjectList(rest)
+	case "remove", "rm":
+		cmdProjectRemove(rest)
+	default:
+		printProjectUsage()
+		os.Exit(2)
+	}
+}
+
+func printProjectUsage() {
+	fmt.Fprintln(os.Stderr, "usage: cux project create <name> [--dir PATH]     bind a directory (default: cwd)")
+	fmt.Fprintln(os.Stderr, "       cux project assign <name> <slot|email|alias> [...]")
+	fmt.Fprintln(os.Stderr, "       cux project unassign <name> <slot|email|alias> [...]")
+	fmt.Fprintln(os.Stderr, "       cux project list [--refresh]")
+	fmt.Fprintln(os.Stderr, "       cux project remove <name>")
+}
+
+func withState(fn func(*store.State) error) {
+	lk, err := lockfile.Acquire(paths.LockFile(), 10*time.Second)
+	if err != nil {
+		fail(err)
+	}
+	defer lk.Unlock() //nolint:errcheck
+	state, err := store.Load()
+	if err != nil {
+		fail(err)
+	}
+	if err := fn(state); err != nil {
+		fail(err)
+	}
+	if err := state.Save(); err != nil {
+		fail(err)
+	}
+}
+
+func cmdProjectCreate(args []string) {
+	// Name first, flags after: `cux project create iht --dir ~/code/iht`.
+	// Go's flag parser stops at the first positional, so split by hand.
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		printProjectUsage()
+		os.Exit(2)
+	}
+	name := args[0]
+	fs := flag.NewFlagSet("project create", flag.ExitOnError)
+	dir := fs.String("dir", "", "directory the project claims (default: current directory)")
+	_ = fs.Parse(args[1:])
+	if fs.NArg() != 0 {
+		printProjectUsage()
+		os.Exit(2)
+	}
+	d := *dir
+	if d == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fail(err)
+		}
+		d = cwd
+	}
+	abs, err := filepath.Abs(d)
+	if err != nil {
+		fail(err)
+	}
+	withState(func(state *store.State) error {
+		return state.AddProject(name, abs)
+	})
+	fmt.Printf("Created project %s → %s. Assign seats with `cux project assign %s <slot|alias>`.\n", name, abs, name)
+}
+
+func cmdProjectMutate(args []string, assign bool) {
+	if len(args) < 2 {
+		printProjectUsage()
+		os.Exit(2)
+	}
+	name, seats := args[0], args[1:]
+	withState(func(state *store.State) error {
+		for _, seat := range seats {
+			acct, err := state.Resolve(seat)
+			if err != nil {
+				return err
+			}
+			if assign {
+				if err := state.AssignProjectSlot(name, acct.Slot); err != nil {
+					return err
+				}
+				fmt.Printf("Assigned slot %d (%s) to %s.\n", acct.Slot, acct.Email, name)
+			} else {
+				if err := state.UnassignProjectSlot(name, acct.Slot); err != nil {
+					return err
+				}
+				fmt.Printf("Unassigned slot %d (%s) from %s.\n", acct.Slot, acct.Email, name)
+			}
+		}
+		return nil
+	})
+}
+
+func cmdProjectRemove(args []string) {
+	if len(args) != 1 {
+		printProjectUsage()
+		os.Exit(2)
+	}
+	withState(func(state *store.State) error {
+		return state.RemoveProject(args[0])
+	})
+	fmt.Printf("Removed project %s. Accounts are untouched.\n", args[0])
+}
+
+func cmdProjectList(args []string) {
+	fs := flag.NewFlagSet("project list", flag.ExitOnError)
+	refresh := fs.Bool("refresh", false, "fetch fresh usage before printing")
+	_ = fs.Parse(args)
+
+	if *refresh {
+		if _, errs := monitor.RefreshAll(); len(errs) > 0 {
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "warning: %v\n", e)
+			}
+		}
+	}
+	state, err := store.Load()
+	if err != nil {
+		fail(err)
+	}
+	if len(state.Projects) == 0 {
+		fmt.Println("No projects defined. Create one with `cux project create <name> [--dir PATH]`.")
+		return
+	}
+	cache, _ := usage.LoadCache()
+
+	names := make([]string, 0, len(state.Projects))
+	for n := range state.Projects {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		p := state.Projects[n]
+		fmt.Printf("%s  %s\n", p.Name, p.Dir)
+		if len(p.Slots) == 0 {
+			fmt.Println("  (no seats assigned — full pool applies here)")
+			continue
+		}
+		for _, slot := range p.Slots {
+			acct, ok := state.Accounts[slot]
+			if !ok {
+				continue
+			}
+			label := acct.Email
+			if acct.Alias != "" {
+				label = acct.Alias + " · " + acct.Email
+			}
+			line := fmt.Sprintf("  [%02d] %-42s", slot, label)
+			if cache != nil {
+				if u, ok := cache[acct.CacheKey()]; ok {
+					line += "  5h:" + windowPct(u.FiveHour) + "  7d:" + windowPct(u.SevenDay)
+					if u.TokenExpired {
+						line += "  (needs login)"
+					}
+				} else {
+					line += "  (no usage data — try --refresh)"
+				}
+			}
+			fmt.Println(line)
+		}
+	}
+}
+
 func cmdAlias(args []string) {
 	fs := flag.NewFlagSet("alias", flag.ExitOnError)
 	clear := fs.Bool("clear", false, "remove the alias from this account")
@@ -1695,6 +1880,11 @@ USAGE
   cux add [--slot N] [--alias NAME] [--no-alias]  add the currently logged-in account
   cux list                                list managed accounts
   cux alias <slot|email|alias> <name>     set a short alias (e.g. work, personal)
+  cux project create <name> [--dir PATH]  scope a directory to its own seat pool
+  cux project assign <name> <seat> [...]  add seats to a project (seats can be shared)
+  cux project unassign <name> <seat> [...]
+  cux project list [--refresh]            projects + live usage of their seats
+  cux project remove <name>               unbind a directory (accounts untouched)
   cux alias <slot|email|alias> --clear    remove alias
   cux switch <slot|email|alias>           swap the active account (manual; requires
                                           restart unless run from /switch inside)

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -207,8 +207,9 @@ func handleAutoSwitchPrompt(prompt string, stdout io.Writer) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
-	for _, a := range state.Accounts {
+	pool := state.PoolForCwd()
+	candidates := make([]strategy.Candidate, 0, len(pool))
+	for _, a := range pool {
 		candidates = append(candidates, strategy.Candidate{Email: a.Email, CacheKey: a.CacheKey()})
 	}
 	current := strategy.Candidate{Email: email, CacheKey: cacheKey}
@@ -434,8 +435,9 @@ func promptSwitchHasTarget() (bool, string) {
 		cache = usage.Cache{}
 	}
 	current, _ := switcher.CurrentLiveEmail()
-	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
-	for _, a := range state.Accounts {
+	pool := state.PoolForCwd()
+	candidates := make([]strategy.Candidate, 0, len(pool))
+	for _, a := range pool {
 		candidates = append(candidates, strategy.Candidate{Email: a.Email})
 	}
 	if _, ok := strategy.PickNext(cfg.ResolvedStrategy(), cfg.Strategy.Order, candidates,
@@ -443,7 +445,10 @@ func promptSwitchHasTarget() (bool, string) {
 		return true, ""
 	}
 	for _, slot := range state.SortedSlots() {
-		acct := state.Accounts[slot]
+		acct, inPool := pool[slot]
+		if !inPool {
+			continue
+		}
 		if slot != state.ActiveSlot && accountHasPromptCapacity(cache, acct, cfg.Thresholds) {
 			return true, ""
 		}

--- a/internal/lockfile/lockfile_windows.go
+++ b/internal/lockfile/lockfile_windows.go
@@ -13,10 +13,10 @@ import (
 // LOCKFILE_FAIL_IMMEDIATELY for non-blocking try-lock semantics that
 // match flock(LOCK_EX|LOCK_NB) on Unix.
 const (
-	lockExclusive  = windows.LOCKFILE_EXCLUSIVE_LOCK
-	lockNonBlock   = windows.LOCKFILE_FAIL_IMMEDIATELY
-	lockBytesLow   = ^uint32(0)
-	lockBytesHigh  = ^uint32(0)
+	lockExclusive = windows.LOCKFILE_EXCLUSIVE_LOCK
+	lockNonBlock  = windows.LOCKFILE_FAIL_IMMEDIATELY
+	lockBytesLow  = ^uint32(0)
+	lockBytesHigh = ^uint32(0)
 )
 
 func tryLock(f *os.File) error {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -101,12 +101,12 @@ func BackupRoot() string {
 	return filepath.Join(Home(), ".cux")
 }
 
-func StateFile() string    { return filepath.Join(BackupRoot(), "state.json") }
-func AccountsDir() string  { return filepath.Join(BackupRoot(), "accounts") }
-func RuntimeDir() string   { return filepath.Join(BackupRoot(), "runtime") }
+func StateFile() string     { return filepath.Join(BackupRoot(), "state.json") }
+func AccountsDir() string   { return filepath.Join(BackupRoot(), "accounts") }
+func RuntimeDir() string    { return filepath.Join(BackupRoot(), "runtime") }
 func ClaudePIDFile() string { return filepath.Join(RuntimeDir(), "claude.pid") }
-func PendingFile() string  { return filepath.Join(RuntimeDir(), "pending.json") }
-func LockFile() string     { return filepath.Join(BackupRoot(), ".lock") }
+func PendingFile() string   { return filepath.Join(RuntimeDir(), "pending.json") }
+func LockFile() string      { return filepath.Join(BackupRoot(), ".lock") }
 
 // ReplayFlagFile is a one-shot file written by the wrapper before it relaunches
 // Claude with a replayed prompt. The UserPromptSubmit hook reads and deletes it

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Projects scope the account pool per directory. A machine that hosts
+// several codebases often wants them on distinct seats — different
+// clients billed to different orgs, a personal side project kept off
+// the company pool — while still sharing some accounts between related
+// projects. A project binds a directory to a subset of managed slots;
+// the wrapper resolves the project from its working directory and every
+// automatic decision (threshold swap, rate-limit rotation,
+// wait-for-reset) draws candidates from that subset only.
+//
+// Backward compatible by construction: with no projects defined, or in
+// a directory no project claims, the pool is the full account list —
+// exactly today's behavior. Explicit targets (`/switch <seat>`,
+// `cux switch <seat>`) are never restricted: a human naming a seat
+// outranks the project boundary.
+
+// Project binds a directory to a subset of managed slots.
+type Project struct {
+	Name  string `json:"name"`
+	Dir   string `json:"dir"`             // absolute, cleaned
+	Slots []int  `json:"slots,omitempty"` // empty = full pool until seats are assigned
+}
+
+var projectNameRE = regexp.MustCompile(`^[a-z][a-z0-9-]{0,31}$`)
+
+// ErrProjectExists / ErrProjectMissing mirror the account errors.
+var (
+	ErrProjectExists  = errors.New("store: project already exists")
+	ErrProjectMissing = errors.New("store: project not found")
+)
+
+// ValidateProjectName returns an error if s is not a valid project name.
+func ValidateProjectName(s string) error {
+	if !projectNameRE.MatchString(s) {
+		return fmt.Errorf("store: project name %q must start with a letter, contain only lowercase letters, digits, or hyphens, and be at most 32 chars", s)
+	}
+	return nil
+}
+
+// AddProject registers a project. dir must be absolute; it is cleaned
+// before storage so prefix matching stays canonical.
+func (s *State) AddProject(name, dir string) error {
+	if err := ValidateProjectName(name); err != nil {
+		return err
+	}
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("store: project dir must be absolute, got %q", dir)
+	}
+	if s.Projects == nil {
+		s.Projects = map[string]Project{}
+	}
+	if _, ok := s.Projects[name]; ok {
+		return fmt.Errorf("%w: %s", ErrProjectExists, name)
+	}
+	dir = filepath.Clean(dir)
+	for _, p := range s.Projects {
+		if p.Dir == dir {
+			return fmt.Errorf("store: project %q already claims %s", p.Name, dir)
+		}
+	}
+	s.Projects[name] = Project{Name: name, Dir: dir}
+	return nil
+}
+
+// RemoveProject unregisters a project. Accounts themselves are untouched.
+func (s *State) RemoveProject(name string) error {
+	if _, ok := s.Projects[name]; !ok {
+		return fmt.Errorf("%w: %s", ErrProjectMissing, name)
+	}
+	delete(s.Projects, name)
+	return nil
+}
+
+// AssignProjectSlot adds a seat to a project's pool. A slot may belong
+// to any number of projects — shared accounts are the point.
+func (s *State) AssignProjectSlot(name string, slot int) error {
+	p, ok := s.Projects[name]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrProjectMissing, name)
+	}
+	if _, ok := s.Accounts[slot]; !ok {
+		return fmt.Errorf("%w: slot %d", ErrAccountMissing, slot)
+	}
+	for _, existing := range p.Slots {
+		if existing == slot {
+			return nil // idempotent
+		}
+	}
+	p.Slots = append(p.Slots, slot)
+	sort.Ints(p.Slots)
+	s.Projects[name] = p
+	return nil
+}
+
+// UnassignProjectSlot removes a seat from a project's pool. Removal is
+// idempotent — unassigning a seat that is not there is not an error.
+func (s *State) UnassignProjectSlot(name string, slot int) error {
+	p, ok := s.Projects[name]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrProjectMissing, name)
+	}
+	out := p.Slots[:0]
+	for _, existing := range p.Slots {
+		if existing != slot {
+			out = append(out, existing)
+		}
+	}
+	p.Slots = out
+	s.Projects[name] = p
+	return nil
+}
+
+// ProjectFor returns the project whose directory contains cwd, choosing
+// the longest (most specific) match so nested projects work. Matching
+// is path-boundary aware: /a/b claims /a/b and /a/b/c, never /a/bc.
+// Returns nil when no project claims cwd.
+func (s *State) ProjectFor(cwd string) *Project {
+	cwd = filepath.Clean(cwd)
+	var best *Project
+	for name := range s.Projects {
+		p := s.Projects[name]
+		if !dirContains(p.Dir, cwd) {
+			continue
+		}
+		if best == nil || len(p.Dir) > len(best.Dir) {
+			best = &p
+		}
+	}
+	return best
+}
+
+// PoolFor returns the accounts automatic decisions may draw from in
+// cwd, plus the project that scoped them (nil = unrestricted). The
+// full pool comes back when no project claims cwd, when the matching
+// project has no seats assigned yet, or when none of its assigned
+// seats still exist.
+func (s *State) PoolFor(cwd string) (map[int]Account, *Project) {
+	p := s.ProjectFor(cwd)
+	if p == nil || len(p.Slots) == 0 {
+		return s.Accounts, p
+	}
+	pool := make(map[int]Account, len(p.Slots))
+	for _, slot := range p.Slots {
+		if a, ok := s.Accounts[slot]; ok {
+			pool[slot] = a
+		}
+	}
+	if len(pool) == 0 {
+		// Every assigned seat has since been removed — falling back to
+		// the full pool beats stranding the session.
+		return s.Accounts, p
+	}
+	return pool, p
+}
+
+// dirContains reports whether path lives inside root (or is root).
+func dirContains(root, path string) bool {
+	if root == path {
+		return true
+	}
+	return strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// PoolForCwd is PoolFor for the current working directory — the shape
+// the wrapper and hooks always want, since decisions are scoped to the
+// directory claude runs in. Falls back to the full pool when the
+// working directory cannot be determined.
+func (s *State) PoolForCwd() map[int]Account {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return s.Accounts
+	}
+	pool, _ := s.PoolFor(cwd)
+	return pool
+}

--- a/internal/store/projects_test.go
+++ b/internal/store/projects_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func projectFixture(t *testing.T) *State {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	s := &State{
+		Accounts: map[int]Account{
+			1: {Slot: 1, Email: "a@x.test"},
+			2: {Slot: 2, Email: "b@x.test"},
+			3: {Slot: 3, Email: "c@x.test"},
+		},
+		Sequence: []int{1, 2, 3},
+	}
+	if err := s.AddProject("alpha", "/work/alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddProject("beta", "/work/beta"); err != nil {
+		t.Fatal(err)
+	}
+	for _, slot := range []int{1, 2} {
+		if err := s.AssignProjectSlot("alpha", slot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Slot 2 is shared between the two projects; slot 3 belongs to beta.
+	for _, slot := range []int{2, 3} {
+		if err := s.AssignProjectSlot("beta", slot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func poolSlots(pool map[int]Account) []int {
+	out := []int{}
+	for slot := range pool {
+		out = append(out, slot)
+	}
+	return out
+}
+
+func TestPoolForScopesByDirectory(t *testing.T) {
+	s := projectFixture(t)
+
+	pool, p := s.PoolFor("/work/alpha/src")
+	if p == nil || p.Name != "alpha" {
+		t.Fatalf("project = %v, want alpha", p)
+	}
+	if len(pool) != 2 || pool[1].Email != "a@x.test" || pool[2].Email != "b@x.test" {
+		t.Errorf("alpha pool = %v, want slots 1,2", poolSlots(pool))
+	}
+
+	// Shared seat: slot 2 must appear in beta's pool too.
+	pool, p = s.PoolFor("/work/beta")
+	if p == nil || p.Name != "beta" {
+		t.Fatalf("project = %v, want beta", p)
+	}
+	if len(pool) != 2 || pool[2].Email != "b@x.test" || pool[3].Email != "c@x.test" {
+		t.Errorf("beta pool = %v, want slots 2,3", poolSlots(pool))
+	}
+
+	// Unclaimed directory → full pool, today's behavior.
+	pool, p = s.PoolFor("/somewhere/else")
+	if p != nil || len(pool) != 3 {
+		t.Errorf("unclaimed dir: got project %v, pool %v; want full pool", p, poolSlots(pool))
+	}
+
+	// Path-boundary awareness: /work/alphabet is NOT inside /work/alpha.
+	if _, p := s.PoolFor("/work/alphabet"); p != nil {
+		t.Errorf("/work/alphabet matched %s — prefix match must be path-boundary aware", p.Name)
+	}
+}
+
+func TestPoolForNestedProjectsLongestWins(t *testing.T) {
+	s := projectFixture(t)
+	if err := s.AddProject("alpha-sub", filepath.Join("/work/alpha", "vendor")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AssignProjectSlot("alpha-sub", 3); err != nil {
+		t.Fatal(err)
+	}
+	if _, p := s.PoolFor("/work/alpha/vendor/pkg"); p == nil || p.Name != "alpha-sub" {
+		t.Errorf("nested dir resolved to %v, want alpha-sub (longest match)", p)
+	}
+	if _, p := s.PoolFor("/work/alpha/src"); p == nil || p.Name != "alpha" {
+		t.Errorf("outer dir resolved to %v, want alpha", p)
+	}
+}
+
+func TestProjectWithNoSeatsFallsBackToFullPool(t *testing.T) {
+	s := projectFixture(t)
+	if err := s.AddProject("empty", "/work/empty"); err != nil {
+		t.Fatal(err)
+	}
+	pool, p := s.PoolFor("/work/empty")
+	if p == nil || p.Name != "empty" {
+		t.Fatalf("project = %v, want empty", p)
+	}
+	if len(pool) != 3 {
+		t.Errorf("empty project pool = %v, want full pool until seats are assigned", poolSlots(pool))
+	}
+}
+
+func TestRemoveAccountCleansProjectAssignments(t *testing.T) {
+	s := projectFixture(t)
+	if err := s.Remove(2); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"alpha", "beta"} {
+		for _, slot := range s.Projects[name].Slots {
+			if slot == 2 {
+				t.Errorf("removed slot 2 still assigned to %s", name)
+			}
+		}
+	}
+}
+
+func TestProjectLifecycleValidation(t *testing.T) {
+	s := projectFixture(t)
+	if err := s.AddProject("alpha", "/elsewhere"); err == nil {
+		t.Error("duplicate project name must be rejected")
+	}
+	if err := s.AddProject("dup-dir", "/work/alpha"); err == nil {
+		t.Error("duplicate project dir must be rejected")
+	}
+	if err := s.AddProject("Bad Name", "/x"); err == nil {
+		t.Error("invalid project name must be rejected")
+	}
+	if err := s.AddProject("rel", "relative/path"); err == nil {
+		t.Error("relative dir must be rejected")
+	}
+	if err := s.AssignProjectSlot("alpha", 99); err == nil {
+		t.Error("assigning an unknown slot must be rejected")
+	}
+	if err := s.AssignProjectSlot("alpha", 1); err != nil {
+		t.Errorf("re-assigning an assigned slot must be idempotent, got %v", err)
+	}
+	if err := s.UnassignProjectSlot("alpha", 3); err != nil {
+		t.Errorf("unassigning a not-assigned slot must be idempotent, got %v", err)
+	}
+	if err := s.RemoveProject("ghost"); err == nil {
+		t.Error("removing an unknown project must be rejected")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -51,13 +51,14 @@ func (a Account) CacheKey() string {
 
 // State is the on-disk shape of state.json.
 type State struct {
-	Version          int             `json:"version"`
-	ActiveSlot       int             `json:"activeSlot"`
-	LastUpdated      time.Time       `json:"lastUpdated"`
-	Sequence         []int           `json:"sequence"` // user-visible ordering for `cux switch` rotation
-	Accounts         map[int]Account `json:"accounts"`
-	ManualSwitchEmail string         `json:"manualSwitchEmail,omitempty"`
-	ManualSwitchAt    time.Time      `json:"manualSwitchAt,omitempty"`
+	Version           int                `json:"version"`
+	ActiveSlot        int                `json:"activeSlot"`
+	LastUpdated       time.Time          `json:"lastUpdated"`
+	Sequence          []int              `json:"sequence"` // user-visible ordering for `cux switch` rotation
+	Accounts          map[int]Account    `json:"accounts"`
+	Projects          map[string]Project `json:"projects,omitempty"` // per-directory account pools
+	ManualSwitchEmail string             `json:"manualSwitchEmail,omitempty"`
+	ManualSwitchAt    time.Time          `json:"manualSwitchAt,omitempty"`
 }
 
 var (
@@ -116,6 +117,7 @@ func Load() (*State, error) {
 		LastUpdated       time.Time          `json:"lastUpdated"`
 		Sequence          []int              `json:"sequence"`
 		Accounts          map[string]Account `json:"accounts"`
+		Projects          map[string]Project `json:"projects,omitempty"`
 		ManualSwitchEmail string             `json:"manualSwitchEmail,omitempty"`
 		ManualSwitchAt    time.Time          `json:"manualSwitchAt,omitempty"`
 	}
@@ -129,6 +131,7 @@ func Load() (*State, error) {
 		LastUpdated:       raw.LastUpdated,
 		Sequence:          raw.Sequence,
 		Accounts:          make(map[int]Account, len(raw.Accounts)),
+		Projects:          raw.Projects,
 		ManualSwitchEmail: raw.ManualSwitchEmail,
 		ManualSwitchAt:    raw.ManualSwitchAt,
 	}
@@ -166,9 +169,10 @@ func (s *State) Save() error {
 		LastUpdated       time.Time          `json:"lastUpdated"`
 		Sequence          []int              `json:"sequence"`
 		Accounts          map[string]Account `json:"accounts"`
+		Projects          map[string]Project `json:"projects,omitempty"`
 		ManualSwitchEmail string             `json:"manualSwitchEmail,omitempty"`
 		ManualSwitchAt    time.Time          `json:"manualSwitchAt,omitempty"`
-	}{s.Version, s.ActiveSlot, s.LastUpdated, s.Sequence, accounts, s.ManualSwitchEmail, s.ManualSwitchAt}
+	}{s.Version, s.ActiveSlot, s.LastUpdated, s.Sequence, accounts, s.Projects, s.ManualSwitchEmail, s.ManualSwitchAt}
 
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -316,6 +320,10 @@ func (s *State) Remove(slot int) error {
 		return fmt.Errorf("%w: slot %d", ErrAccountMissing, slot)
 	}
 	delete(s.Accounts, slot)
+	// A removed account must not linger in any project pool.
+	for name := range s.Projects {
+		_ = s.UnassignProjectSlot(name, slot)
+	}
 	out := s.Sequence[:0]
 	for _, n := range s.Sequence {
 		if n != slot {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -31,17 +31,17 @@ import (
 // for testing or migration to a future header value, so we don't have
 // to ship a new binary if Anthropic rolls the beta tag.
 const (
-	defaultEndpoint  = "https://api.anthropic.com/api/oauth/usage"
-	defaultBetaHdr   = "oauth-2025-04-20"
-	envEndpoint      = "CUX_USAGE_ENDPOINT"
-	envBetaHeader    = "CUX_USAGE_BETA"
-	cacheFileName    = "usage-cache.json"
-	httpTimeout      = 10 * time.Second
+	defaultEndpoint = "https://api.anthropic.com/api/oauth/usage"
+	defaultBetaHdr  = "oauth-2025-04-20"
+	envEndpoint     = "CUX_USAGE_ENDPOINT"
+	envBetaHeader   = "CUX_USAGE_BETA"
+	cacheFileName   = "usage-cache.json"
+	httpTimeout     = 10 * time.Second
 )
 
 // Window is one usage interval reported by the API.
 type Window struct {
-	Utilization float64    `json:"utilization"`        // 0.0–100.0
+	Utilization float64    `json:"utilization"`         // 0.0–100.0
 	ResetsAt    *time.Time `json:"resets_at,omitempty"` // nil if API returned null
 }
 

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -623,8 +623,9 @@ func evaluateThresholdSwap(cfg *config.Config, manualTarget string) *pending {
 	if err != nil {
 		return nil
 	}
-	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
-	for _, a := range state.Accounts {
+	pool := state.PoolForCwd()
+	candidates := make([]strategy.Candidate, 0, len(pool))
+	for _, a := range pool {
 		candidates = append(candidates, strategy.Candidate{Email: a.Email, CacheKey: a.CacheKey()})
 	}
 	current := strategy.Candidate{Email: email, CacheKey: cacheKey}
@@ -733,7 +734,7 @@ func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (str
 			return "", err
 		}
 		cache, _ := usage.LoadCache()
-		readyAt, email, ok := nextAvailability(state.Accounts, cache, cfg.Thresholds, time.Now())
+		readyAt, email, ok := nextAvailability(state.PoolForCwd(), cache, cfg.Thresholds, time.Now())
 		if !ok {
 			return "", errors.New("all accounts exhausted and no reset time is known")
 		}
@@ -948,8 +949,13 @@ func resolveTarget(explicit string, trigger history.Trigger, cfg *config.Config)
 	if err != nil {
 		return "", err
 	}
-	if len(state.Accounts) < 2 {
-		return "", errors.New("only one account is managed; nothing to rotate to")
+	// Rotation draws from the project pool for this directory (the full
+	// account list when no project claims it). Explicit targets bypass
+	// this function entirely — a human naming a seat outranks the
+	// project boundary.
+	pool := state.PoolForCwd()
+	if len(pool) < 2 {
+		return "", errors.New("only one account is available here; nothing to rotate to")
 	}
 	current, _ := switcher.CurrentLiveEmail()
 	currentCacheKey, _ := switcher.CurrentLiveCacheKey()
@@ -962,8 +968,8 @@ func resolveTarget(explicit string, trigger history.Trigger, cfg *config.Config)
 	if cache == nil {
 		cache = usage.Cache{}
 	}
-	candidates := make([]strategy.Candidate, 0, len(state.Accounts))
-	for _, a := range state.Accounts {
+	candidates := make([]strategy.Candidate, 0, len(pool))
+	for _, a := range pool {
 		candidates = append(candidates, strategy.Candidate{Email: a.Email, CacheKey: a.CacheKey()})
 	}
 	// In manual mode strategy.PickNext returns ok=false, but a manual
@@ -984,8 +990,9 @@ func resolveTarget(explicit string, trigger history.Trigger, cfg *config.Config)
 // that are known to have no capacity. Missing usage is treated as usable so
 // fresh installs can rotate before the first refresh completes.
 func rotateFallback(state *store.State, cache usage.Cache, cfg *config.Config) (string, error) {
+	pool := state.PoolForCwd()
 	for _, slot := range rotationSlots(state) {
-		acct, ok := state.Accounts[slot]
+		acct, ok := pool[slot]
 		if !ok || slot == state.ActiveSlot {
 			continue
 		}


### PR DESCRIPTION
Implements #27. We built this because we run several codebases on one machine and need seats scoped per project (billing/compliance), with some seats shared between related projects — details and motivation table in the issue. If it doesn't fit your v0.3 direction, feel free to close; we'll keep it on our fork either way.

## What it does

`cux project create|assign|unassign|list|remove` bind a directory to a subset of seats. The wrapper resolves the project from its working directory and every automatic decision draws candidates from that subset only.

## Where the pool is enforced

| Decision path | Change |
|---|---|
| Threshold swap (`evaluateThresholdSwap`) | candidates ← project pool |
| Rate-limit / manual rotation (`resolveTarget`) | candidates ← project pool; "only one account" check is pool-scoped |
| Rotate fallback (`rotateFallback`) | walks only pool slots |
| Prompt-submit hook (threshold switch + all-exhausted verdict) | pool-scoped |
| `wait_for_reset` availability math (`nextAvailability`) | pool-scoped |
| Explicit `/switch <seat>`, `cux switch <seat>` | **deliberately unrestricted** |
| Display commands (`cux list`, usage panel) | unchanged — global view |

## Compatibility (see issue table for the full matrix)

- No projects / unclaimed dir / project without seats / all seats since removed → **full pool, bit-for-bit today's behavior**
- `cux remove` cleans the seat out of every project pool
- Old cux versions ignore the unknown `projects` key in state.json
- Matching is longest-prefix and path-boundary aware (`/a/b` claims `/a/b/c`, never `/a/bc`; nested projects resolve to the deepest match)

## Tested on macOS 15 (arm64)

- `internal/store/projects_test.go`: directory scoping incl. shared seats, path-boundary edge (`/work/alphabet` vs `/work/alpha`), nested longest-match, empty-project fallback, account-removal cleanup, full lifecycle validation (dupe name/dir, invalid name, relative dir, unknown slot, idempotent assign/unassign)
- Full `go test ./...` passes (12 packages); `go vet` + `gofmt` clean
- CLI exercised end-to-end against a real 4-account setup: create → multi-assign (incl. a seat shared by two projects) → `list` with live usage → unassign → remove

README gets a Projects section; `cux help` lists the new commands.