### PR TITLE
feat: session heartbeat registry and cux sessions

### DIFF
--- a/cmd/cux/main.go
+++ b/cmd/cux/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/inulute/cux/internal/lockfile"
 	"github.com/inulute/cux/internal/monitor"
 	"github.com/inulute/cux/internal/paths"
+	"github.com/inulute/cux/internal/registry"
 	"github.com/inulute/cux/internal/store"
 	"github.com/inulute/cux/internal/switcher"
 	"github.com/inulute/cux/internal/updater"
@@ -70,6 +71,7 @@ var knownSubcommands = map[string]bool{
 	"remove":          true,
 	"rm":              true,
 	"status":          true,
+	"sessions":        true,
 	"support":         true,
 	"switch":          true,
 	"force-switch":    true,
@@ -119,6 +121,8 @@ func main() {
 		cmdAlias(rest)
 	case "status":
 		cmdStatus(rest)
+	case "sessions":
+		cmdSessions(rest)
 	case "support":
 		cmdSupport(rest)
 	case "switch":
@@ -314,6 +318,47 @@ func cmdAlias(args []string) {
 	} else {
 		fmt.Printf("Set alias %q for slot %d (%s).\n", newAlias, acct.Slot, acct.Email)
 	}
+}
+
+// cmdSessions lists every live cux wrapper on this machine from the
+// heartbeat registry: which directory, which seat, what state. This is
+// the first place N concurrent sessions become visible at all —
+// `cux list` shows seats, this shows the sessions using them.
+func cmdSessions(args []string) {
+	_ = args
+	entries := registry.List()
+	if len(entries) == 0 {
+		fmt.Println("No cux sessions are running.")
+		return
+	}
+	now := time.Now()
+	for _, e := range entries {
+		state := e.State
+		if e.Detail != "" {
+			state += " (" + e.Detail + ")"
+		}
+		sid := e.SessionID
+		if len(sid) > 8 {
+			sid = sid[:8]
+		}
+		if sid == "" {
+			sid = "-"
+		}
+		fmt.Printf("[%d] %s\n", e.PID, e.CWD)
+		fmt.Printf("    seat %-28s session %-9s %s\n", e.Seat, sid, state)
+		fmt.Printf("    up %s, last change %s ago\n",
+			formatDuration(now.Sub(e.StartedAt)), formatDuration(now.Sub(e.UpdatedAt)))
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Minute)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %02dm", h, m)
+	}
+	return fmt.Sprintf("%dm", m)
 }
 
 func cmdStatus(args []string) {
@@ -1702,6 +1747,7 @@ USAGE
                                           when Claude will not run /switch
   cux remove [--force] <slot|email|alias> remove an account from cux
   cux status                              show live login + cux state
+  cux sessions                            list running cux sessions (heartbeat registry)
   cux support                             show support URL
   cux docs                                show documentation URL
   cux setup                               install /switch, /cux:* + Claude Code hooks

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,124 @@
+// Package registry is the wrapper's heartbeat: every running cux
+// wrapper self-reports what it is doing into one small JSON file under
+// the runtime directory. Until now N concurrent sessions were invisible
+// — `cux list` shows seats, nothing shows sessions. The registry makes
+// "what is running on this machine, on which seat, in which state"
+// answerable, for `cux sessions` today and for remote monitoring
+// surfaces later.
+//
+// One file per wrapper PID, single writer (the wrapper itself), atomic
+// writes — no locking needed. Liveness is decided by the reader: an
+// entry whose PID is gone is a leftover from a crash and is cleaned up
+// on the next List.
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/inulute/cux/internal/atomicfile"
+	"github.com/inulute/cux/internal/paths"
+)
+
+// States a wrapper can report.
+const (
+	StateRunning      = "running"
+	StateSwapping     = "swapping"
+	StateRetrying     = "retrying"
+	StateWaitingReset = "waiting-reset"
+)
+
+// Entry is one running wrapper's self-reported status.
+type Entry struct {
+	PID       int       `json:"pid"`
+	CWD       string    `json:"cwd"`
+	SessionID string    `json:"sessionId,omitempty"`
+	Seat      string    `json:"seat,omitempty"` // email claude was last launched on
+	State     string    `json:"state"`
+	Detail    string    `json:"detail,omitempty"` // human hint: "reset in 1h23m", "attempt 3"
+	StartedAt time.Time `json:"startedAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func dir() string { return filepath.Join(paths.RuntimeDir(), "sessions") }
+
+func file(pid int) string { return filepath.Join(dir(), strconv.Itoa(pid)+".json") }
+
+// UpdateSelf mutates (or creates) the calling process's entry. Errors
+// are swallowed on purpose: the heartbeat must never break a swap.
+func UpdateSelf(mutate func(*Entry)) {
+	pid := os.Getpid()
+	e := Entry{PID: pid, StartedAt: time.Now().UTC()}
+	if b, err := os.ReadFile(file(pid)); err == nil {
+		_ = json.Unmarshal(b, &e)
+	}
+	if e.CWD == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			e.CWD = cwd
+		}
+	}
+	mutate(&e)
+	e.PID = pid
+	e.UpdatedAt = time.Now().UTC()
+	if err := os.MkdirAll(dir(), 0o700); err != nil {
+		return
+	}
+	if b, err := json.MarshalIndent(e, "", "  "); err == nil {
+		_ = atomicfile.Write(file(pid), b, 0o600)
+	}
+}
+
+// RemoveSelf deletes the calling process's entry (normal exit).
+func RemoveSelf() {
+	_ = os.Remove(file(os.Getpid()))
+}
+
+// List returns every live wrapper's entry, oldest first. Entries whose
+// process is gone are removed best-effort and not returned.
+func List() []Entry {
+	entries, err := os.ReadDir(dir())
+	if err != nil {
+		return nil
+	}
+	var out []Entry
+	for _, de := range entries {
+		if de.IsDir() || filepath.Ext(de.Name()) != ".json" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir(), de.Name()))
+		if err != nil {
+			continue
+		}
+		var e Entry
+		if json.Unmarshal(b, &e) != nil || e.PID == 0 {
+			continue
+		}
+		if !processAlive(e.PID) {
+			_ = os.Remove(filepath.Join(dir(), de.Name()))
+			continue
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].StartedAt.Before(out[j].StartedAt) })
+	return out
+}
+
+// processAlive probes pid with the null signal. On platforms where the
+// probe is unsupported it reports true, so entries are kept rather
+// than wrongly reaped.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	return err == syscall.EPERM
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,96 @@
+package registry
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestUpdateListRemoveLifecycle(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	UpdateSelf(func(e *Entry) {
+		e.State = StateRunning
+		e.Seat = "a@x.test"
+	})
+	UpdateSelf(func(e *Entry) {
+		e.State = StateWaitingReset
+		e.Detail = "resets in 1h"
+		e.SessionID = "sid-123"
+	})
+
+	entries := List()
+	if len(entries) != 1 {
+		t.Fatalf("List() returned %d entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.PID != os.Getpid() || e.State != StateWaitingReset || e.Seat != "a@x.test" || e.SessionID != "sid-123" {
+		t.Errorf("entry = %+v — fields not preserved across updates", e)
+	}
+	if e.StartedAt.IsZero() || e.UpdatedAt.Before(e.StartedAt) {
+		t.Errorf("timestamps look wrong: started=%v updated=%v", e.StartedAt, e.UpdatedAt)
+	}
+
+	RemoveSelf()
+	if got := List(); len(got) != 0 {
+		t.Errorf("after RemoveSelf List() = %v, want empty", got)
+	}
+}
+
+func TestListReapsDeadProcesses(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// A real process that has already exited: its PID is dead by the
+	// time List runs, so the entry must be reaped, not returned.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	deadPID := cmd.Process.Pid
+	_ = cmd.Wait()
+
+	UpdateSelf(func(e *Entry) { e.State = StateRunning })
+	// Forge the dead process's entry by rewriting our own file's PID.
+	entries := List()
+	if len(entries) != 1 {
+		t.Fatalf("setup: %d entries", len(entries))
+	}
+	self := entries[0]
+	self.PID = deadPID
+	self.UpdatedAt = time.Now().UTC()
+	b, _ := os.ReadFile(file(os.Getpid()))
+	_ = b
+	if err := os.Rename(file(os.Getpid()), file(deadPID)); err != nil {
+		t.Fatal(err)
+	}
+	// Rewrite content so the stored PID matches the dead one.
+	UpdateSelf(func(e *Entry) { e.State = StateRunning })
+	forge := file(deadPID)
+	data := []byte(`{"pid":` + itoa(deadPID) + `,"cwd":"/x","state":"running","startedAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}`)
+	if err := os.WriteFile(forge, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := List()
+	if len(got) != 1 || got[0].PID != os.Getpid() {
+		t.Errorf("List() = %+v, want only the live self entry", got)
+	}
+	if _, err := os.Stat(forge); !os.IsNotExist(err) {
+		t.Error("dead entry file should have been reaped")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -37,6 +37,7 @@ import (
 	"github.com/inulute/cux/internal/history"
 	"github.com/inulute/cux/internal/monitor"
 	"github.com/inulute/cux/internal/paths"
+	"github.com/inulute/cux/internal/registry"
 	"github.com/inulute/cux/internal/signals"
 	"github.com/inulute/cux/internal/store"
 	"github.com/inulute/cux/internal/strategy"
@@ -93,6 +94,11 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 		fmt.Fprintf(w, "cux: warning: cannot publish wrapper pid: %v\n", err)
 	}
 	defer cleanupWrapperPID(pid)
+	// Heartbeat: self-report what this wrapper is doing so that
+	// `cux sessions` (and remote surfaces reading the same registry)
+	// can show every concurrent session at a glance.
+	registry.UpdateSelf(func(e *registry.Entry) { e.State = registry.StateRunning })
+	defer registry.RemoveSelf()
 
 	// lastManualTarget holds the email the user explicitly switched to
 	// within this wrapper session. Threshold auto-switch is suppressed
@@ -133,9 +139,19 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 	var apiRetries int
 
 	for {
+		if seat, err := switcher.CurrentLiveEmail(); err == nil {
+			registry.UpdateSelf(func(e *registry.Entry) {
+				e.State = registry.StateRunning
+				e.Seat = seat
+				e.Detail = ""
+			})
+		}
 		exitCode, sessionID, hadTurns, p, err := launch(claudeBin, currentArgv, pid, &cfg, lastManualTarget, w)
 		if err != nil {
 			return exitCode, err
+		}
+		if sessionID != "" {
+			registry.UpdateSelf(func(e *registry.Entry) { e.SessionID = sessionID })
 		}
 
 		if p != nil && p.retryOnly {
@@ -146,6 +162,10 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			apiRetries++
 			fmt.Fprintf(w, "cux: API failure after claude's own retries (%s) — auto-continuing in %s (attempt %d)…\n",
 				snippet(p.reason), shortDuration(delay), apiRetries)
+			registry.UpdateSelf(func(e *registry.Entry) {
+				e.State = registry.StateRetrying
+				e.Detail = fmt.Sprintf("attempt %d, next try in %s", apiRetries, shortDuration(delay))
+			})
 			time.Sleep(delay)
 			if sessionID != "" && cfg.AutoResume {
 				cwd, _ := os.Getwd()
@@ -210,6 +230,7 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			return exitCode, nil
 		}
 
+		registry.UpdateSelf(func(e *registry.Entry) { e.State = registry.StateSwapping })
 		from, to, swapErr := switcher.SwitchTo(target)
 		if swapErr != nil {
 			fmt.Fprintf(w, "cux: switch failed: %v\n", swapErr)
@@ -743,6 +764,10 @@ func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (str
 		}
 		fmt.Fprintf(w, "cux: all accounts exhausted — waiting %s for %s to reset…\n",
 			shortDuration(d), email)
+		registry.UpdateSelf(func(e *registry.Entry) {
+			e.State = registry.StateWaitingReset
+			e.Detail = fmt.Sprintf("%s resets in %s", email, shortDuration(d))
+		})
 		time.Sleep(d)
 		_, _ = monitor.RefreshAll()
 		if target, err := resolveTarget("", trigger, cfg); err == nil {


### PR DESCRIPTION
## Why

Running several cux sessions in several terminals is normal for heavy users (see #21), but they're invisible: `cux list` shows seats, nothing shows the *sessions* using them. Overnight questions like "is my run alive, which seat is it on, is it waiting for a reset or stuck retrying?" have no answer today.

## What

Each wrapper self-reports into `runtime/sessions/<pid>.json`:

| Field | Meaning |
|---|---|
| `cwd` | where the session runs |
| `seat` | email claude was last launched on |
| `sessionId` | for `cux --resume` |
| `state` | `running` / `swapping` / `retrying` / `waiting-reset` |
| `detail` | human hint: "attempt 3, next try in 30s", "ogz@… resets in 1h23m" |

Updated at every state transition, removed on clean exit. One file per wrapper PID, single writer, atomic writes — no locking. Liveness is the reader's job: `List()` reaps entries whose PID is dead, so crashes leave nothing stale. Fire-and-forget by design (errors swallowed): the heartbeat must never break a swap.

```
$ cux sessions
[73820] /Users/me/code/client
    seat oguz@x.com   session 1634fada  waiting-reset (ogz@x.com resets in 1h23m)
    up 6h 12m, last change 0m ago
```

Beyond the CLI, this is the data source any monitoring surface needs — a dashboard (local web panel, menubar applet…) can watch one tiny directory instead of instrumenting the wrapper.

## Tested on macOS 15 (arm64)

- Unit tests: update/list/remove lifecycle with field preservation across updates; dead-PID reaping via a real exited process
- Live smoke: a `cux -p` run appears in `cux sessions` with seat + state while running, disappears on exit
- `go vet ./...` clean, full `go test ./...` passes (13 packages)