### PR TITLE
feat: attachable sessions — mirror and control any cux session, no tmux

### DIFF
--- a/cmd/cux/attach.go
+++ b/cmd/cux/attach.go
@@ -1,0 +1,123 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/inulute/cux/internal/paths"
+	"github.com/inulute/cux/internal/ptyhost"
+	"github.com/inulute/cux/internal/registry"
+	"golang.org/x/term"
+)
+
+const detachKey = 0x1c // Ctrl+\
+
+// cmdAttach mirrors a running cux session into this terminal — the
+// tmux-attach experience without tmux. With no argument it attaches to
+// the only attachable session; with one it takes the wrapper PID shown
+// by `cux sessions`.
+func cmdAttach(args []string) int {
+	pid, err := pickSession(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "cux:", err)
+		return 1
+	}
+	conn, err := net.Dial("unix", paths.AttachSock(pid))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cux: cannot attach to %d: %v\n(is the session running a cux build with attach support?)\n", pid, err)
+		return 1
+	}
+	defer conn.Close()
+
+	fd := int(os.Stdin.Fd())
+	old, err := term.MakeRaw(fd)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "cux: attach needs a terminal:", err)
+		return 1
+	}
+	defer term.Restore(fd, old)
+	fmt.Printf("cux: attached to %d — detach with Ctrl+\\\r\n", pid)
+
+	sendSize := func() {
+		if cols, rows, err := term.GetSize(fd); err == nil {
+			p := []byte{byte(rows >> 8), byte(rows), byte(cols >> 8), byte(cols)}
+			_ = ptyhost.WriteFrame(conn, ptyhost.FrameResize, p)
+		}
+	}
+	sendSize()
+	winch := make(chan os.Signal, 1)
+	signal.Notify(winch, syscall.SIGWINCH)
+	go func() {
+		for range winch {
+			sendSize()
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() { // socket → terminal
+		defer close(done)
+		for {
+			typ, payload, err := ptyhost.ReadFrame(conn)
+			if err != nil {
+				return
+			}
+			if typ == ptyhost.FrameOut {
+				_, _ = os.Stdout.Write(payload)
+			}
+		}
+	}()
+
+	go func() { // terminal → socket, scanning for the detach key
+		buf := make([]byte, 4096)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if err != nil {
+				return
+			}
+			for i := 0; i < n; i++ {
+				if buf[i] == detachKey {
+					_ = conn.Close()
+					return
+				}
+			}
+			if err := ptyhost.WriteFrame(conn, ptyhost.FrameInput, buf[:n]); err != nil {
+				return
+			}
+		}
+	}()
+
+	<-done
+	fmt.Print("\r\ncux: detached\r\n")
+	return 0
+}
+
+// pickSession resolves the target wrapper PID: an explicit argument
+// wins; otherwise the registry must hold exactly one attachable entry.
+func pickSession(args []string) (int, error) {
+	if len(args) > 0 {
+		var pid int
+		if _, err := fmt.Sscanf(args[0], "%d", &pid); err != nil {
+			return 0, fmt.Errorf("attach: %q is not a pid (see `cux sessions`)", args[0])
+		}
+		return pid, nil
+	}
+	var attachable []registry.Entry
+	for _, e := range registry.List() {
+		if e.Attachable {
+			attachable = append(attachable, e)
+		}
+	}
+	switch len(attachable) {
+	case 0:
+		return 0, fmt.Errorf("no attachable sessions (see `cux sessions`)")
+	case 1:
+		return attachable[0].PID, nil
+	default:
+		return 0, fmt.Errorf("%d attachable sessions — pick one: `cux attach <pid>` (see `cux sessions`)", len(attachable))
+	}
+}

--- a/cmd/cux/attach_windows.go
+++ b/cmd/cux/attach_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func cmdAttach(args []string) int {
+	fmt.Fprintln(os.Stderr, "cux: attach is not supported on Windows yet")
+	return 1
+}

--- a/cmd/cux/main.go
+++ b/cmd/cux/main.go
@@ -74,6 +74,7 @@ var knownSubcommands = map[string]bool{
 	"rm":              true,
 	"status":          true,
 	"sessions":        true,
+	"attach":          true,
 	"support":         true,
 	"switch":          true,
 	"force-switch":    true,
@@ -125,6 +126,8 @@ func main() {
 		cmdProject(rest)
 	case "status":
 		cmdStatus(rest)
+	case "attach":
+		os.Exit(cmdAttach(rest))
 	case "sessions":
 		cmdSessions(rest)
 	case "support":

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.25.9
 
 require (
 	github.com/zalando/go-keyring v0.2.8
-	golang.org/x/sys v0.28.0
-	golang.org/x/term v0.27.0
+	golang.org/x/sys v0.47.0
+	golang.org/x/term v0.45.0
 )
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/inulute/cux
 go 1.25.9
 
 require (
+	github.com/creack/pty v1.1.24
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 )
 
 require (
-	github.com/creack/pty v1.1.24 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -14,7 +16,11 @@ github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPc
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,11 @@ type Config struct {
 	PollIntervalSeconds   int               `json:"poll_interval_seconds"`
 	UpdateCheck           UpdateCheckConfig `json:"update_check"`
 	Theme                 string            `json:"theme"`
+	// Attach exposes each session on a local Unix socket so `cux attach`
+	// (and tools like cuxdeck) can mirror the terminal; AttachInput
+	// additionally lets attached clients type into the session.
+	Attach      bool `json:"attach"`
+	AttachInput bool `json:"attach_input"`
 }
 
 // ResolvedStrategy returns the parsed strategy.Kind.
@@ -95,6 +100,8 @@ func Defaults() Config {
 		PollIntervalSeconds:   60,
 		UpdateCheck:           UpdateCheckConfig{Enabled: true, CadenceHours: 6},
 		Theme:                 "claude",
+		Attach:                true,
+		AttachInput:           true,
 	}
 }
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -9,6 +9,7 @@
 package paths
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -105,8 +106,13 @@ func StateFile() string     { return filepath.Join(BackupRoot(), "state.json") }
 func AccountsDir() string   { return filepath.Join(BackupRoot(), "accounts") }
 func RuntimeDir() string    { return filepath.Join(BackupRoot(), "runtime") }
 func ClaudePIDFile() string { return filepath.Join(RuntimeDir(), "claude.pid") }
-func PendingFile() string   { return filepath.Join(RuntimeDir(), "pending.json") }
-func LockFile() string      { return filepath.Join(BackupRoot(), ".lock") }
+
+// AttachDir holds per-wrapper attach sockets for `cux attach` and
+// remote bridges; AttachSock names one wrapper's socket.
+func AttachDir() string         { return filepath.Join(RuntimeDir(), "attach") }
+func AttachSock(pid int) string { return filepath.Join(AttachDir(), fmt.Sprintf("%d.sock", pid)) }
+func PendingFile() string       { return filepath.Join(RuntimeDir(), "pending.json") }
+func LockFile() string          { return filepath.Join(BackupRoot(), ".lock") }
 
 // ReplayFlagFile is a one-shot file written by the wrapper before it relaunches
 // Claude with a replayed prompt. The UserPromptSubmit hook reads and deletes it

--- a/internal/ptyhost/attach_replay_test.go
+++ b/internal/ptyhost/attach_replay_test.go
@@ -4,7 +4,9 @@ package ptyhost
 
 import (
 	"bytes"
+	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -32,5 +34,30 @@ func TestBacklogReplayedOnAttach(t *testing.T) {
 	}
 	if typ != FrameOut || !bytes.Contains(payload, []byte("PRIOR-OUTPUT-LINE")) {
 		t.Fatalf("first frame should replay backlog; got typ=%d payload=%q", typ, payload)
+	}
+}
+
+// TestNoReplayWhileAltScreen checks that when the app is on the alternate
+// screen (a full-screen TUI like claude), attaching does NOT dump the raw
+// history — that would render off-screen on a differently sized client and
+// blank the view. With no PTY child to repaint in the test, the client
+// should simply receive nothing.
+func TestNoReplayWhileAltScreen(t *testing.T) {
+	h, err := New(filepath.Join(t.TempDir(), "s.sock"), true)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+	h.hist.record([]byte("\x1b[?1049h\x1b[2J\x1b[Hfull-screen frame at host size"))
+
+	conn, err := net.Dial("unix", h.sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+	_, _, err = readFrame(conn)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected no replay frame on the alt screen (read should time out); got err=%v", err)
 	}
 }

--- a/internal/ptyhost/attach_replay_test.go
+++ b/internal/ptyhost/attach_replay_test.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package ptyhost
+
+import (
+	"bytes"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestBacklogReplayedOnAttach checks a newly attached client receives the
+// prior output (scrollback) as its first frame, not just live output.
+func TestBacklogReplayedOnAttach(t *testing.T) {
+	h, err := New(filepath.Join(t.TempDir(), "s.sock"), true)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+	h.hist.record([]byte("PRIOR-OUTPUT-LINE"))
+
+	conn, err := net.Dial("unix", h.sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	typ, payload, err := readFrame(conn)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if typ != FrameOut || !bytes.Contains(payload, []byte("PRIOR-OUTPUT-LINE")) {
+		t.Fatalf("first frame should replay backlog; got typ=%d payload=%q", typ, payload)
+	}
+}

--- a/internal/ptyhost/frame.go
+++ b/internal/ptyhost/frame.go
@@ -1,0 +1,57 @@
+// The attach socket's framed protocol, shared by the Unix (ptyhost.go)
+// and Windows (ptyhost_windows.go) hosts and by `cux attach` / bridges:
+//
+//	[1 byte type][4 bytes big-endian length][payload]
+//
+//	0 out    — PTY output (host → client)
+//	1 input  — keystrokes for the PTY (client → host)
+//	2 resize — payload rows,cols as two big-endian uint16 (client → host)
+//	3 ping   — keepalive, either direction, empty payload
+package ptyhost
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+const (
+	FrameOut byte = iota
+	FrameInput
+	FrameResize
+	FramePing
+)
+
+var errFrameTooBig = errors.New("ptyhost: frame exceeds limit")
+
+const maxFrame = 1 << 20
+
+func writeFrame(w io.Writer, typ byte, payload []byte) error {
+	hdr := [5]byte{typ}
+	binary.BigEndian.PutUint32(hdr[1:], uint32(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+func readFrame(r io.Reader) (byte, []byte, error) {
+	var hdr [5]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return 0, nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[1:])
+	if n > maxFrame {
+		return 0, nil, errFrameTooBig
+	}
+	payload := make([]byte, n)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	return hdr[0], payload, nil
+}
+
+// WriteFrame / ReadFrame are exported for `cux attach` and bridges.
+func WriteFrame(w io.Writer, typ byte, payload []byte) error { return writeFrame(w, typ, payload) }
+func ReadFrame(r io.Reader) (byte, []byte, error)            { return readFrame(r) }

--- a/internal/ptyhost/history.go
+++ b/internal/ptyhost/history.go
@@ -1,0 +1,38 @@
+package ptyhost
+
+import "sync"
+
+// maxHistory is how much recent PTY output the host keeps so a freshly
+// attached client can be handed the backlog (scrollback) instead of just
+// the current frame. ~512 KiB covers thousands of lines — enough to
+// scroll back through, cheap to hold per session.
+const maxHistory = 512 * 1024
+
+// history is a byte ring of the most recent PTY output, replayed to each
+// new client on attach. Without it a viewer only ever sees output that
+// arrives after it connects, so scrollback is empty.
+type history struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+// record appends output, trimming to the last maxHistory bytes. The trim
+// re-backs the slice so the dropped prefix can be collected rather than
+// pinned by a growing underlying array.
+func (h *history) record(p []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.buf = append(h.buf, p...)
+	if len(h.buf) > maxHistory {
+		h.buf = append([]byte(nil), h.buf[len(h.buf)-maxHistory:]...)
+	}
+}
+
+// snapshot returns a copy of the current backlog for replay.
+func (h *history) snapshot() []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]byte, len(h.buf))
+	copy(out, h.buf)
+	return out
+}

--- a/internal/ptyhost/history.go
+++ b/internal/ptyhost/history.go
@@ -1,6 +1,9 @@
 package ptyhost
 
-import "sync"
+import (
+	"bytes"
+	"sync"
+)
 
 // maxHistory is how much recent PTY output the host keeps so a freshly
 // attached client can be handed the backlog (scrollback) instead of just
@@ -8,12 +11,32 @@ import "sync"
 // scroll back through, cheap to hold per session.
 const maxHistory = 512 * 1024
 
+// altScreenCarry is how many trailing bytes of one write we re-scan with
+// the next, so an alt-screen toggle split across two writes is still
+// seen. It only needs to cover the longest toggle sequence below.
+const altScreenCarry = 8
+
+// The DEC private toggles for the alternate screen buffer. A full-screen
+// TUI enters the alt screen and repaints via absolute cursor addressing
+// sized to the current terminal.
+var (
+	altEnter = [][]byte{[]byte("\x1b[?1049h"), []byte("\x1b[?1047h"), []byte("\x1b[?47h")}
+	altExit  = [][]byte{[]byte("\x1b[?1049l"), []byte("\x1b[?1047l"), []byte("\x1b[?47l")}
+)
+
 // history is a byte ring of the most recent PTY output, replayed to each
-// new client on attach. Without it a viewer only ever sees output that
-// arrives after it connects, so scrollback is empty.
+// new client on attach so scrollback is not empty. It also tracks whether
+// the app is currently on the alternate screen buffer: for a full-screen
+// TUI (claude, vim, less) the raw history is a stream of absolute-cursor
+// repaints sized to the host terminal, so replaying it to a differently
+// sized client renders off-screen — blank. While the alt screen is
+// active the host suppresses replay and lets the redraw nudge repaint the
+// current screen at the client's own size instead.
 type history struct {
-	mu  sync.Mutex
-	buf []byte
+	mu   sync.Mutex
+	buf  []byte
+	alt  bool   // app is currently on the alternate screen buffer
+	tail []byte // trailing bytes of the last write, for split-toggle detection
 }
 
 // record appends output, trimming to the last maxHistory bytes. The trim
@@ -22,16 +45,65 @@ type history struct {
 func (h *history) record(p []byte) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.scanAlt(p)
 	h.buf = append(h.buf, p...)
 	if len(h.buf) > maxHistory {
 		h.buf = append([]byte(nil), h.buf[len(h.buf)-maxHistory:]...)
 	}
 }
 
-// snapshot returns a copy of the current backlog for replay.
+// scanAlt updates h.alt from the alt-screen toggles in p. The last toggle
+// in the joined window wins, so a chunk that enters then exits (or vice
+// versa) lands on its final state.
+func (h *history) scanAlt(p []byte) {
+	window := p
+	if len(h.tail) > 0 {
+		window = append(append([]byte(nil), h.tail...), p...)
+	}
+	lastEnter, lastExit := -1, -1
+	for _, s := range altEnter {
+		if i := bytes.LastIndex(window, s); i > lastEnter {
+			lastEnter = i
+		}
+	}
+	for _, s := range altExit {
+		if i := bytes.LastIndex(window, s); i > lastExit {
+			lastExit = i
+		}
+	}
+	if lastEnter > lastExit {
+		h.alt = true
+	} else if lastExit > lastEnter {
+		h.alt = false
+	}
+	if len(window) > altScreenCarry {
+		h.tail = append(h.tail[:0], window[len(window)-altScreenCarry:]...)
+	} else {
+		h.tail = append(h.tail[:0], window...)
+	}
+}
+
+// replay returns the backlog to hand a newly attached client, or nil when
+// the app is on the alternate screen — there the redraw nudge repaints the
+// current screen at the client's size, which raw history cannot do.
+func (h *history) replay() []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.alt {
+		return nil
+	}
+	return h.copyLocked()
+}
+
+// snapshot returns a copy of the recorded backlog regardless of screen
+// mode. Unlike replay it is not gated on the alt screen.
 func (h *history) snapshot() []byte {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.copyLocked()
+}
+
+func (h *history) copyLocked() []byte {
 	out := make([]byte, len(h.buf))
 	copy(out, h.buf)
 	return out

--- a/internal/ptyhost/history_test.go
+++ b/internal/ptyhost/history_test.go
@@ -20,3 +20,36 @@ func TestHistoryRingTrims(t *testing.T) {
 		t.Fatal("newest byte was lost")
 	}
 }
+
+func TestHistoryAltScreenSuppressesReplay(t *testing.T) {
+	var h history
+	h.record([]byte("shell output before the TUI\n"))
+	if h.replay() == nil {
+		t.Fatal("normal-screen output should be replayed")
+	}
+	// A full-screen TUI enters the alt screen: replay must be suppressed.
+	h.record([]byte("\x1b[?1049h\x1b[2J\x1b[Hpainting a full-screen frame"))
+	if h.replay() != nil {
+		t.Fatal("alt-screen output must not be replayed (would render off-screen)")
+	}
+	// The backlog is still retained — snapshot is not gated on alt screen.
+	if len(h.snapshot()) == 0 {
+		t.Fatal("history should still be recorded while on the alt screen")
+	}
+	// Leaving the alt screen restores replay.
+	h.record([]byte("\x1b[?1049lback to the shell\n"))
+	if h.replay() == nil {
+		t.Fatal("replay should resume after leaving the alt screen")
+	}
+}
+
+func TestHistoryAltScreenToggleSplitAcrossWrites(t *testing.T) {
+	var h history
+	// The enter sequence \x1b[?1049h is split across two record calls; the
+	// carry window must still detect it.
+	h.record([]byte("output\x1b[?10"))
+	h.record([]byte("49h\x1b[2Jframe"))
+	if h.replay() != nil {
+		t.Fatal("split alt-screen enter should still suppress replay")
+	}
+}

--- a/internal/ptyhost/history_test.go
+++ b/internal/ptyhost/history_test.go
@@ -1,0 +1,22 @@
+package ptyhost
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHistoryRingTrims(t *testing.T) {
+	var h history
+	h.record(bytes.Repeat([]byte("a"), 10))
+	h.record(bytes.Repeat([]byte("b"), maxHistory))
+	snap := h.snapshot()
+	if len(snap) != maxHistory {
+		t.Fatalf("snapshot len = %d, want %d", len(snap), maxHistory)
+	}
+	if bytes.Contains(snap, []byte("a")) {
+		t.Fatal("oldest bytes should have been trimmed")
+	}
+	if snap[len(snap)-1] != 'b' {
+		t.Fatal("newest byte was lost")
+	}
+}

--- a/internal/ptyhost/mastereof_test.go
+++ b/internal/ptyhost/mastereof_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package ptyhost
 
 import (

--- a/internal/ptyhost/mastereof_test.go
+++ b/internal/ptyhost/mastereof_test.go
@@ -1,0 +1,51 @@
+package ptyhost
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestMasterSurvivesChildExit locks in the Setctty fix: after a child on
+// the slave exits, the master (ptmx) must still be alive (a Read blocks
+// waiting for the next launch) rather than returning EOF. If it returned
+// EOF, Pump() would exit and the next relaunch (a rate-limit resume)
+// would hang — exactly the "resuming on …" freeze this guards against.
+func TestMasterSurvivesChildExit(t *testing.T) {
+	h, err := New(filepath.Join(t.TempDir(), "s.sock"), false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+
+	tty, err := h.TTYDup()
+	if err != nil {
+		t.Fatalf("dup: %v", err)
+	}
+	cmd := exec.Command("true")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+	cmd.SysProcAttr = SysProcAttr()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	_ = cmd.Wait()
+	_ = tty.Close()
+
+	type res struct {
+		n   int
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, e := h.ptmx.Read(buf)
+		ch <- res{n, e}
+	}()
+	select {
+	case r := <-ch:
+		t.Fatalf("master.Read returned (%d, %v) after child exit — Pump would die and relaunch would hang; Setctty must stay off", r.n, r.err)
+	case <-time.After(700 * time.Millisecond):
+		// Still blocked → master alive → Pump survives → relaunch works.
+	}
+}

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -120,10 +120,20 @@ func (h *Host) TTYDup() (*os.File, error) {
 	return os.OpenFile(h.tty.Name(), os.O_RDWR, 0)
 }
 
-// SysProcAttr returns the attributes a child needs to adopt the PTY as
-// its controlling terminal.
+// SysProcAttr returns the attributes for launching claude on the PTY.
+//
+// Setsid puts claude in its own session (isolated from cux's own
+// terminal). We deliberately do NOT set Setctty: making the slave the
+// child's controlling terminal means the child, as session leader,
+// revokes that terminal when it exits — which lands on the shared master
+// as EOF and kills Pump(), so the next relaunch (a rate-limit resume)
+// writes into a master nobody reads and hangs. Without Setctty the
+// master stays alive across launches. claude still sees a real tty on
+// its stdio (isatty true; size/raw handled via the master), and Ctrl-C /
+// input arrive as bytes written into the PTY, so no controlling terminal
+// is needed.
 func SysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setsid: true, Setctty: true}
+	return &syscall.SysProcAttr{Setsid: true}
 }
 
 // Pump mirrors the user's terminal into and out of the PTY. It returns

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -1,0 +1,308 @@
+//go:build !windows
+
+// Package ptyhost makes a cux session attachable. The wrapper runs
+// claude on a pseudo-terminal it owns instead of inheriting the user's
+// terminal directly; the host then mirrors bytes between the real
+// terminal, the PTY, and any number of attached clients on a Unix
+// socket — the dtach/tmux model, in-process.
+//
+// Because the PTY belongs to the wrapper (not to any single claude
+// child), it survives the kill+resume relaunches cux performs on
+// account swaps: attached viewers stay connected straight through a
+// seat change.
+//
+// The socket speaks a minimal framed protocol, shared with `cux attach`
+// and remote surfaces like cuxdeck:
+//
+//	[1 byte type][4 bytes big-endian length][payload]
+//
+//	0 out    — PTY output (host → client)
+//	1 input  — keystrokes for the PTY (client → host)
+//	2 resize — payload rows,cols as two big-endian uint16 (client → host)
+//	3 ping   — keepalive, either direction, empty payload
+//
+// On attach the host nudges the PTY size (shrink one row, restore).
+// Full-screen programs repaint on SIGWINCH, so the new client gets a
+// clean frame without the host having to emulate a terminal.
+package ptyhost
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/creack/pty"
+	"golang.org/x/term"
+)
+
+const (
+	FrameOut byte = iota
+	FrameInput
+	FrameResize
+	FramePing
+)
+
+// Host owns the PTY pair and the attach socket for one wrapper.
+type Host struct {
+	ptmx *os.File // master: host reads output, writes input
+	tty  *os.File // slave: children run on this
+
+	ln       net.Listener
+	sockPath string
+	inputOK  bool
+
+	mu      sync.Mutex
+	clients map[net.Conn]*clientState
+	local   winsize // the user's real terminal, zero when unknown
+	closed  bool
+}
+
+type clientState struct{ size winsize }
+
+type winsize struct{ rows, cols uint16 }
+
+// New opens the PTY pair, sizes it to the current terminal, and starts
+// serving attach clients on sockPath (created 0600). inputOK gates
+// whether client keystrokes are forwarded to the PTY.
+func New(sockPath string, inputOK bool) (*Host, error) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		return nil, err
+	}
+	h := &Host{ptmx: ptmx, tty: tty, sockPath: sockPath, inputOK: inputOK,
+		clients: map[net.Conn]*clientState{}}
+
+	if w, hgt, err := term.GetSize(int(os.Stdin.Fd())); err == nil {
+		h.local = winsize{rows: uint16(hgt), cols: uint16(w)}
+	}
+	if h.local.rows == 0 {
+		h.local = winsize{rows: 24, cols: 80}
+	}
+	h.applySize()
+
+	_ = os.Remove(sockPath)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		_ = ptmx.Close()
+		_ = tty.Close()
+		return nil, err
+	}
+	_ = os.Chmod(sockPath, 0o600)
+	h.ln = ln
+
+	go h.acceptLoop()
+	go h.watchWinch()
+	return h, nil
+}
+
+// TTY exposes the slave for exec.Cmd wiring: set it as the child's
+// stdin/stdout/stderr together with SysProcAttr(), once per (re)launch;
+// the PTY persists across children.
+func (h *Host) TTY() *os.File { return h.tty }
+
+// SysProcAttr returns the attributes a child needs to adopt the PTY as
+// its controlling terminal.
+func SysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true, Setctty: true}
+}
+
+// Pump mirrors the user's terminal into and out of the PTY. It returns
+// when the PTY closes. Call from Run once; it owns os.Stdin/os.Stdout.
+func (h *Host) Pump() {
+	go func() { _, _ = io.Copy(h.ptmx, os.Stdin) }()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := h.ptmx.Read(buf)
+		if n > 0 {
+			_, _ = os.Stdout.Write(buf[:n])
+			h.broadcast(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// BroadcastWriter returns a writer that mirrors wrapper status messages
+// (the "cux: …" lines printed between launches) to attached clients so
+// remote viewers see the same narration the local terminal does.
+func (h *Host) BroadcastWriter() io.Writer { return broadcastWriter{h} }
+
+type broadcastWriter struct{ h *Host }
+
+func (b broadcastWriter) Write(p []byte) (int, error) { b.h.broadcast(p); return len(p), nil }
+
+func (h *Host) broadcast(p []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for c := range h.clients {
+		if err := writeFrame(c, FrameOut, p); err != nil {
+			_ = c.Close()
+			delete(h.clients, c)
+		}
+	}
+}
+
+func (h *Host) acceptLoop() {
+	for {
+		conn, err := h.ln.Accept()
+		if err != nil {
+			return
+		}
+		h.mu.Lock()
+		h.clients[conn] = &clientState{}
+		h.mu.Unlock()
+		go h.serve(conn)
+		h.redraw()
+	}
+}
+
+// serve reads one client's frames until it disconnects.
+func (h *Host) serve(conn net.Conn) {
+	defer func() {
+		h.mu.Lock()
+		delete(h.clients, conn)
+		h.mu.Unlock()
+		_ = conn.Close()
+		h.recomputeSize()
+	}()
+	for {
+		typ, payload, err := readFrame(conn)
+		if err != nil {
+			return
+		}
+		switch typ {
+		case FrameInput:
+			if h.inputOK {
+				_, _ = h.ptmx.Write(payload)
+			}
+		case FrameResize:
+			if len(payload) == 4 {
+				h.mu.Lock()
+				h.clients[conn].size = winsize{
+					rows: binary.BigEndian.Uint16(payload[0:2]),
+					cols: binary.BigEndian.Uint16(payload[2:4]),
+				}
+				h.mu.Unlock()
+				h.recomputeSize()
+			}
+		case FramePing:
+			_ = writeFrame(conn, FramePing, nil)
+		}
+	}
+}
+
+// recomputeSize applies the tmux rule: the effective PTY size is the
+// smallest of every participant that has declared one, so no viewer
+// ever sees a clipped frame.
+func (h *Host) recomputeSize() {
+	h.mu.Lock()
+	eff := h.local
+	for _, c := range h.clients {
+		if c.size.rows == 0 || c.size.cols == 0 {
+			continue
+		}
+		if eff.rows == 0 || c.size.rows < eff.rows {
+			eff.rows = c.size.rows
+		}
+		if eff.cols == 0 || c.size.cols < eff.cols {
+			eff.cols = c.size.cols
+		}
+	}
+	h.mu.Unlock()
+	if eff.rows == 0 {
+		return
+	}
+	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: eff.rows, Cols: eff.cols})
+}
+
+func (h *Host) applySize() {
+	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: h.local.rows, Cols: h.local.cols})
+}
+
+// redraw nudges the PTY one row smaller and back so full-screen
+// programs repaint — a fresh attach sees the current frame.
+func (h *Host) redraw() {
+	h.mu.Lock()
+	rows, cols := h.local.rows, h.local.cols
+	h.mu.Unlock()
+	if rows < 2 {
+		return
+	}
+	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: rows - 1, Cols: cols})
+	h.recomputeSize()
+}
+
+func (h *Host) watchWinch() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	for range ch {
+		if w, hgt, err := term.GetSize(int(os.Stdin.Fd())); err == nil {
+			h.mu.Lock()
+			h.local = winsize{rows: uint16(hgt), cols: uint16(w)}
+			h.mu.Unlock()
+			h.recomputeSize()
+		}
+	}
+}
+
+// Close tears the socket and PTY down.
+func (h *Host) Close() {
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return
+	}
+	h.closed = true
+	for c := range h.clients {
+		_ = c.Close()
+	}
+	h.mu.Unlock()
+	if h.ln != nil {
+		_ = h.ln.Close()
+	}
+	_ = os.Remove(h.sockPath)
+	_ = h.ptmx.Close()
+	_ = h.tty.Close()
+}
+
+/* ---------- frame protocol ---------- */
+
+var errFrameTooBig = errors.New("ptyhost: frame exceeds limit")
+
+const maxFrame = 1 << 20
+
+func writeFrame(w io.Writer, typ byte, payload []byte) error {
+	hdr := [5]byte{typ}
+	binary.BigEndian.PutUint32(hdr[1:], uint32(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+func readFrame(r io.Reader) (byte, []byte, error) {
+	var hdr [5]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return 0, nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[1:])
+	if n > maxFrame {
+		return 0, nil, errFrameTooBig
+	}
+	payload := make([]byte, n)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	return hdr[0], payload, nil
+}
+
+// WriteFrame / ReadFrame are exported for `cux attach` and bridges.
+func WriteFrame(w io.Writer, typ byte, payload []byte) error { return writeFrame(w, typ, payload) }
+func ReadFrame(r io.Reader) (byte, []byte, error)            { return readFrame(r) }

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/creack/pty"
@@ -53,6 +54,13 @@ type Host struct {
 	local   winsize // the user's real terminal, zero when unknown
 	closed  bool
 	hist    history // recent output, replayed to new clients for scrollback
+
+	// childPID is the current claude process. We run it setsid without a
+	// controlling terminal (see SysProcAttr), so resizing the PTY does not
+	// itself raise SIGWINCH on the child — the kernel only signals a
+	// terminal's controlling process group. We therefore signal the child
+	// directly after every size change so it re-reads the size and reflows.
+	childPID atomic.Int64
 }
 
 type clientState struct {
@@ -130,6 +138,24 @@ func (h *Host) TTYDup() (*os.File, error) {
 // is needed.
 func SysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
+}
+
+// SetChildPID tells the host which claude process to signal on resize.
+// The wrapper calls it after each (re)launch; 0 clears it between launches.
+func (h *Host) SetChildPID(pid int) { h.childPID.Store(int64(pid)) }
+
+// signalChild nudges the current child with SIGWINCH so it re-reads the
+// PTY size and reflows. Because the child has no controlling terminal, a
+// TIOCSWINSZ on the master does not raise SIGWINCH on its own — we deliver
+// it explicitly, to the process and its group (claude is a setsid leader,
+// so -pid covers any helper it spawns).
+func (h *Host) signalChild() {
+	pid := h.childPID.Load()
+	if pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(int(pid), syscall.SIGWINCH)
+	_ = syscall.Kill(-int(pid), syscall.SIGWINCH)
 }
 
 // Pump mirrors the user's terminal into and out of the PTY. It returns
@@ -284,6 +310,7 @@ func (h *Host) recomputeSize() {
 		return
 	}
 	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: eff.rows, Cols: eff.cols})
+	h.signalChild()
 }
 
 func (h *Host) applySize() {
@@ -293,6 +320,7 @@ func (h *Host) applySize() {
 		return
 	}
 	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: h.local.rows, Cols: h.local.cols})
+	h.signalChild()
 }
 
 // redraw nudges the PTY one row smaller and back so full-screen
@@ -305,6 +333,7 @@ func (h *Host) redraw() {
 		return
 	}
 	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: rows - 1, Cols: cols})
+	h.signalChild()
 	h.mu.Unlock()
 	h.recomputeSize()
 }

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -52,6 +52,7 @@ type Host struct {
 	clients map[net.Conn]*clientState
 	local   winsize // the user's real terminal, zero when unknown
 	closed  bool
+	hist    history // recent output, replayed to new clients for scrollback
 }
 
 type clientState struct{ size winsize }
@@ -136,6 +137,7 @@ func (h *Host) Pump() {
 	for {
 		n, err := h.ptmx.Read(buf)
 		if n > 0 {
+			h.hist.record(buf[:n])
 			_, _ = os.Stdout.Write(buf[:n])
 			h.broadcast(buf[:n])
 		}
@@ -179,8 +181,13 @@ func (h *Host) acceptLoop() {
 	}
 }
 
-// serve reads one client's frames until it disconnects.
+// serve reads one client's frames until it disconnects. It first replays
+// the recent-output backlog so the client has scrollback, not just a
+// bare current frame.
 func (h *Host) serve(conn net.Conn) {
+	if b := h.hist.snapshot(); len(b) > 0 {
+		_ = writeFrame(conn, FrameOut, b)
+	}
 	defer func() {
 		h.mu.Lock()
 		delete(h.clients, conn)

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -105,6 +105,21 @@ func New(sockPath string, inputOK bool) (*Host, error) {
 // the PTY persists across children.
 func (h *Host) TTY() *os.File { return h.tty }
 
+// TTYDup opens a FRESH slave handle for one exec.Cmd, from the same
+// pts path as the persistent slave. This is what a child must run on.
+//
+// Why reopen instead of reuse h.tty: os/exec's Wait() closes the stdio
+// files it was handed, and with Setctty the first child becoming the
+// terminal's session leader tears that slave fd down when it exits. Both
+// mean the shared slave can't survive a second launch — the next
+// relaunch (e.g. after a rate-limit account swap) failed with "bad file
+// descriptor". A brand-new open per launch keeps the master (ptmx) and
+// all future relaunches unaffected; the caller wires the returned file
+// as stdin/stdout/stderr and lets exec own its lifecycle.
+func (h *Host) TTYDup() (*os.File, error) {
+	return os.OpenFile(h.tty.Name(), os.O_RDWR, 0)
+}
+
 // SysProcAttr returns the attributes a child needs to adopt the PTY as
 // its controlling terminal.
 func SysProcAttr() *syscall.SysProcAttr {

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -55,7 +55,10 @@ type Host struct {
 	hist    history // recent output, replayed to new clients for scrollback
 }
 
-type clientState struct{ size winsize }
+type clientState struct {
+	size winsize
+	wmu  sync.Mutex // serializes writes to this client's conn (replay, broadcast, ping)
+}
 
 type winsize struct{ rows, cols uint16 }
 
@@ -156,14 +159,38 @@ type broadcastWriter struct{ h *Host }
 
 func (b broadcastWriter) Write(p []byte) (int, error) { b.h.broadcast(p); return len(p), nil }
 
+// writeClient sends one frame to a client, serialized with every other
+// write to the same conn via its clientState.wmu — writeFrame emits a
+// header then a payload as two writes, so without this lock a broadcast
+// could interleave between another writer's header and payload and corrupt
+// the stream. On error the client is dropped.
+func (h *Host) writeClient(conn net.Conn, cs *clientState, typ byte, p []byte) {
+	cs.wmu.Lock()
+	err := writeFrame(conn, typ, p)
+	cs.wmu.Unlock()
+	if err != nil {
+		h.mu.Lock()
+		delete(h.clients, conn)
+		h.mu.Unlock()
+		_ = conn.Close()
+	}
+}
+
 func (h *Host) broadcast(p []byte) {
+	// Snapshot the client set, then write outside h.mu so one slow client
+	// can't stall the whole broadcast (or block accept) while holding it.
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	for c := range h.clients {
-		if err := writeFrame(c, FrameOut, p); err != nil {
-			_ = c.Close()
-			delete(h.clients, c)
-		}
+	type ref struct {
+		conn net.Conn
+		cs   *clientState
+	}
+	refs := make([]ref, 0, len(h.clients))
+	for c, cs := range h.clients {
+		refs = append(refs, ref{c, cs})
+	}
+	h.mu.Unlock()
+	for _, r := range refs {
+		h.writeClient(r.conn, r.cs, FrameOut, p)
 	}
 }
 
@@ -173,21 +200,28 @@ func (h *Host) acceptLoop() {
 		if err != nil {
 			return
 		}
+		cs := &clientState{}
+		// Hold the client's write lock across registration and replay so
+		// the backlog is the first thing written to this conn: any
+		// broadcast that races the new client blocks on wmu until the
+		// replay is out, keeping scrollback strictly before live output.
+		cs.wmu.Lock()
 		h.mu.Lock()
-		h.clients[conn] = &clientState{}
+		h.clients[conn] = cs
+		replay := h.hist.replay()
 		h.mu.Unlock()
-		go h.serve(conn)
+		if len(replay) > 0 {
+			_ = writeFrame(conn, FrameOut, replay)
+		}
+		cs.wmu.Unlock()
+		go h.serve(conn, cs)
 		h.redraw()
 	}
 }
 
-// serve reads one client's frames until it disconnects. It first replays
-// the recent-output backlog so the client has scrollback, not just a
-// bare current frame.
-func (h *Host) serve(conn net.Conn) {
-	if b := h.hist.snapshot(); len(b) > 0 {
-		_ = writeFrame(conn, FrameOut, b)
-	}
+// serve reads one client's frames until it disconnects. The backlog replay
+// (scrollback) already went out in acceptLoop; here we only read.
+func (h *Host) serve(conn net.Conn, cs *clientState) {
 	defer func() {
 		h.mu.Lock()
 		delete(h.clients, conn)
@@ -208,7 +242,7 @@ func (h *Host) serve(conn net.Conn) {
 		case FrameResize:
 			if len(payload) == 4 {
 				h.mu.Lock()
-				h.clients[conn].size = winsize{
+				cs.size = winsize{
 					rows: binary.BigEndian.Uint16(payload[0:2]),
 					cols: binary.BigEndian.Uint16(payload[2:4]),
 				}
@@ -216,7 +250,7 @@ func (h *Host) serve(conn net.Conn) {
 				h.recomputeSize()
 			}
 		case FramePing:
-			_ = writeFrame(conn, FramePing, nil)
+			h.writeClient(conn, cs, FramePing, nil)
 		}
 	}
 }
@@ -224,8 +258,16 @@ func (h *Host) serve(conn net.Conn) {
 // recomputeSize applies the tmux rule: the effective PTY size is the
 // smallest of every participant that has declared one, so no viewer
 // ever sees a clipped frame.
+// recomputeSize holds h.mu across the ioctl. pty.Setsize reads the ptmx
+// fd via Fd(), which bypasses os.File's own lock, so it must be serialized
+// against Close() closing that fd — both happen under h.mu, and the closed
+// guard makes it a no-op once torn down.
 func (h *Host) recomputeSize() {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	eff := h.local
 	for _, c := range h.clients {
 		if c.size.rows == 0 || c.size.cols == 0 {
@@ -238,7 +280,6 @@ func (h *Host) recomputeSize() {
 			eff.cols = c.size.cols
 		}
 	}
-	h.mu.Unlock()
 	if eff.rows == 0 {
 		return
 	}
@@ -246,6 +287,11 @@ func (h *Host) recomputeSize() {
 }
 
 func (h *Host) applySize() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: h.local.rows, Cols: h.local.cols})
 }
 
@@ -254,11 +300,12 @@ func (h *Host) applySize() {
 func (h *Host) redraw() {
 	h.mu.Lock()
 	rows, cols := h.local.rows, h.local.cols
-	h.mu.Unlock()
-	if rows < 2 {
+	if h.closed || rows < 2 {
+		h.mu.Unlock()
 		return
 	}
 	_ = pty.Setsize(h.ptmx, &pty.Winsize{Rows: rows - 1, Cols: cols})
+	h.mu.Unlock()
 	h.recomputeSize()
 }
 
@@ -286,11 +333,12 @@ func (h *Host) Close() {
 	for c := range h.clients {
 		_ = c.Close()
 	}
+	// Close the PTY under h.mu so it can't race an in-flight Setsize ioctl.
+	_ = h.ptmx.Close()
+	_ = h.tty.Close()
 	h.mu.Unlock()
 	if h.ln != nil {
 		_ = h.ln.Close()
 	}
 	_ = os.Remove(h.sockPath)
-	_ = h.ptmx.Close()
-	_ = h.tty.Close()
 }

--- a/internal/ptyhost/ptyhost.go
+++ b/internal/ptyhost/ptyhost.go
@@ -28,7 +28,6 @@ package ptyhost
 
 import (
 	"encoding/binary"
-	"errors"
 	"io"
 	"net"
 	"os"
@@ -38,13 +37,6 @@ import (
 
 	"github.com/creack/pty"
 	"golang.org/x/term"
-)
-
-const (
-	FrameOut byte = iota
-	FrameInput
-	FrameResize
-	FramePing
 )
 
 // Host owns the PTY pair and the attach socket for one wrapper.
@@ -295,39 +287,3 @@ func (h *Host) Close() {
 	_ = h.ptmx.Close()
 	_ = h.tty.Close()
 }
-
-/* ---------- frame protocol ---------- */
-
-var errFrameTooBig = errors.New("ptyhost: frame exceeds limit")
-
-const maxFrame = 1 << 20
-
-func writeFrame(w io.Writer, typ byte, payload []byte) error {
-	hdr := [5]byte{typ}
-	binary.BigEndian.PutUint32(hdr[1:], uint32(len(payload)))
-	if _, err := w.Write(hdr[:]); err != nil {
-		return err
-	}
-	_, err := w.Write(payload)
-	return err
-}
-
-func readFrame(r io.Reader) (byte, []byte, error) {
-	var hdr [5]byte
-	if _, err := io.ReadFull(r, hdr[:]); err != nil {
-		return 0, nil, err
-	}
-	n := binary.BigEndian.Uint32(hdr[1:])
-	if n > maxFrame {
-		return 0, nil, errFrameTooBig
-	}
-	payload := make([]byte, n)
-	if _, err := io.ReadFull(r, payload); err != nil {
-		return 0, nil, err
-	}
-	return hdr[0], payload, nil
-}
-
-// WriteFrame / ReadFrame are exported for `cux attach` and bridges.
-func WriteFrame(w io.Writer, typ byte, payload []byte) error { return writeFrame(w, typ, payload) }
-func ReadFrame(r io.Reader) (byte, []byte, error)            { return readFrame(r) }

--- a/internal/ptyhost/ptyhost_test.go
+++ b/internal/ptyhost/ptyhost_test.go
@@ -1,0 +1,106 @@
+//go:build !windows
+
+package ptyhost
+
+import (
+	"bytes"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAttachRoundTrip runs `cat` on the host PTY, attaches over the
+// Unix socket, types through the socket and expects the echo back —
+// the full remote-input path in one test.
+func TestAttachRoundTrip(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "a.sock")
+	h, err := New(sock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+	go h.Pump()
+
+	cmd := exec.Command("/bin/cat")
+	tty := h.TTY()
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+	cmd.SysProcAttr = SysProcAttr()
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() }()
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := WriteFrame(conn, FrameResize, []byte{0, 30, 0, 100}); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFrame(conn, FrameInput, []byte("merhaba-cux\r")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Collect output frames until the echo shows up (tty echo + cat both
+	// repeat the line, either counts).
+	var got bytes.Buffer
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+		typ, payload, err := ReadFrame(conn)
+		if err == nil && typ == FrameOut {
+			got.Write(payload)
+			if strings.Contains(got.String(), "merhaba-cux") {
+				return
+			}
+		}
+	}
+	t.Fatalf("echo did not arrive; got %q", got.String())
+}
+
+// TestInputGate verifies that a view-only host drops client keystrokes.
+func TestInputGate(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "g.sock")
+	h, err := New(sock, false) // input disabled
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+	go h.Pump()
+
+	cmd := exec.Command("/bin/cat")
+	tty := h.TTY()
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+	cmd.SysProcAttr = SysProcAttr()
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() }()
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := WriteFrame(conn, FrameInput, []byte("sizmamali\r")); err != nil {
+		t.Fatal(err)
+	}
+
+	var got bytes.Buffer
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
+		typ, payload, err := ReadFrame(conn)
+		if err == nil && typ == FrameOut {
+			got.Write(payload)
+		}
+	}
+	if strings.Contains(got.String(), "sizmamali") {
+		t.Fatalf("input leaked through a view-only host: %q", got.String())
+	}
+}

--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+// Attachable sessions require a Unix PTY; on Windows the wrapper falls
+// back to plain stdio inheritance (ConPTY support can follow).
+package ptyhost
+
+import (
+	"errors"
+	"io"
+	"os"
+	"syscall"
+)
+
+var ErrUnsupported = errors.New("ptyhost: not supported on windows")
+
+const (
+	FrameOut byte = iota
+	FrameInput
+	FrameResize
+	FramePing
+)
+
+type Host struct{}
+
+func New(sockPath string, inputOK bool) (*Host, error)       { return nil, ErrUnsupported }
+func (h *Host) TTY() *os.File                                { return nil }
+func (h *Host) Pump()                                        {}
+func (h *Host) BroadcastWriter() io.Writer                   { return io.Discard }
+func (h *Host) Close()                                       {}
+func SysProcAttr() *syscall.SysProcAttr                      { return nil }
+func WriteFrame(w io.Writer, typ byte, payload []byte) error { return ErrUnsupported }
+func ReadFrame(r io.Reader) (byte, []byte, error)            { return 0, nil, ErrUnsupported }

--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -1,33 +1,418 @@
 //go:build windows
 
-// Attachable sessions require a Unix PTY; on Windows the wrapper falls
-// back to plain stdio inheritance (ConPTY support can follow).
+// Windows attach host, built on ConPTY (the Windows pseudo-console).
+// Mirrors the Unix host's contract — New/Pump/BroadcastWriter/Close plus
+// the socket + frame protocol from frame.go — so cux attach and cuxdeck
+// treat both platforms identically. The one shape difference is process
+// launch: os/exec can't attach a ConPTY, so StartAttached spawns claude
+// with CreateProcess + a PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute
+// and returns a `child` the wrapper drives like any other.
 package ptyhost
 
 import (
 	"errors"
 	"io"
+	"net"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-var ErrUnsupported = errors.New("ptyhost: not supported on windows")
+// ErrUnsupported is retained for callers that referenced it; ConPTY is
+// now implemented, so New no longer returns it.
+var ErrUnsupported = errors.New("ptyhost: not supported")
 
-const (
-	FrameOut byte = iota
-	FrameInput
-	FrameResize
-	FramePing
-)
+const procThreadAttributePseudoConsole = 0x00020016
 
-type Host struct{}
+type winsize struct{ rows, cols uint16 }
 
-func New(sockPath string, inputOK bool) (*Host, error)       { return nil, ErrUnsupported }
-func (h *Host) TTY() *os.File                                { return nil }
-func (h *Host) TTYDup() (*os.File, error)                    { return nil, ErrUnsupported }
-func (h *Host) Pump()                                        {}
-func (h *Host) BroadcastWriter() io.Writer                   { return io.Discard }
-func (h *Host) Close()                                       {}
-func SysProcAttr() *syscall.SysProcAttr                      { return nil }
-func WriteFrame(w io.Writer, typ byte, payload []byte) error { return ErrUnsupported }
-func ReadFrame(r io.Reader) (byte, []byte, error)            { return 0, nil, ErrUnsupported }
+type clientState struct{ size winsize }
+
+// Host owns the ConPTY and the attach socket for one wrapper.
+type Host struct {
+	hpc  windows.Handle // pseudo console
+	inW  *os.File       // write end → ConPTY input (host writes keystrokes)
+	outR *os.File       // read end ← ConPTY output (host reads screen)
+
+	ln       net.Listener
+	sockPath string
+	inputOK  bool
+
+	mu      sync.Mutex
+	clients map[net.Conn]*clientState
+	local   winsize
+	closed  bool
+}
+
+// New creates the ConPTY (sized to the current console), keeps the host
+// ends of its pipes, and serves attach clients on sockPath.
+func New(sockPath string, inputOK bool) (*Host, error) {
+	// Two pipes: input (host → console) and output (console → host).
+	var inR, inW, outR, outW windows.Handle
+	if err := windows.CreatePipe(&inR, &inW, nil, 0); err != nil {
+		return nil, err
+	}
+	if err := windows.CreatePipe(&outR, &outW, nil, 0); err != nil {
+		windows.CloseHandle(inR)
+		windows.CloseHandle(inW)
+		return nil, err
+	}
+
+	local := consoleSize()
+	var hpc windows.Handle
+	if err := windows.CreatePseudoConsole(
+		windows.Coord{X: int16(local.cols), Y: int16(local.rows)},
+		inR, outW, 0, &hpc,
+	); err != nil {
+		for _, h := range []windows.Handle{inR, inW, outR, outW} {
+			windows.CloseHandle(h)
+		}
+		return nil, err
+	}
+	// The console dup'd the read/write ends it needs; the host only keeps
+	// the opposite ends.
+	windows.CloseHandle(inR)
+	windows.CloseHandle(outW)
+
+	h := &Host{
+		hpc:      hpc,
+		inW:      os.NewFile(uintptr(inW), "conpty-in"),
+		outR:     os.NewFile(uintptr(outR), "conpty-out"),
+		sockPath: sockPath,
+		inputOK:  inputOK,
+		clients:  map[net.Conn]*clientState{},
+		local:    local,
+	}
+
+	// The attach socket is best-effort: if AF_UNIX is unavailable (older
+	// Windows, or a Wine layer), claude still runs on the ConPTY — it
+	// just isn't mirrored to cux attach / cuxdeck. The ConPTY itself is
+	// the essential part, so a socket error must not sink the session.
+	_ = os.Remove(sockPath)
+	if ln, err := net.Listen("unix", sockPath); err == nil {
+		_ = os.Chmod(sockPath, 0o600)
+		h.ln = ln
+		go h.acceptLoop()
+	}
+	return h, nil
+}
+
+func consoleSize() winsize {
+	// Best effort: query the real console; fall back to 80x24.
+	var info windows.ConsoleScreenBufferInfo
+	if err := windows.GetConsoleScreenBufferInfo(windows.Stdout, &info); err == nil {
+		cols := uint16(info.Window.Right - info.Window.Left + 1)
+		rows := uint16(info.Window.Bottom - info.Window.Top + 1)
+		if cols > 0 && rows > 0 {
+			return winsize{rows: rows, cols: cols}
+		}
+	}
+	return winsize{rows: 24, cols: 80}
+}
+
+// TTY / TTYDup are the Unix wiring points; on Windows the child attaches
+// via StartAttached instead, so these are unused.
+func (h *Host) TTY() *os.File             { return nil }
+func (h *Host) TTYDup() (*os.File, error) { return nil, ErrUnsupported }
+
+// SysProcAttr is unused on Windows (StartAttached builds its own
+// STARTUPINFOEX); returning nil keeps the shared signature satisfied.
+func SysProcAttr() *syscall.SysProcAttr { return nil }
+
+// Pump mirrors the console output to the real stdout and to attached
+// clients, and forwards local stdin into the console. Returns when the
+// console output closes.
+func (h *Host) Pump() {
+	go func() { _, _ = io.Copy(h.inW, os.Stdin) }()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := h.outR.Read(buf)
+		if n > 0 {
+			_, _ = os.Stdout.Write(buf[:n])
+			h.broadcast(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (h *Host) BroadcastWriter() io.Writer { return broadcastWriter{h} }
+
+type broadcastWriter struct{ h *Host }
+
+func (b broadcastWriter) Write(p []byte) (int, error) { b.h.broadcast(p); return len(p), nil }
+
+func (h *Host) broadcast(p []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for c := range h.clients {
+		if err := writeFrame(c, FrameOut, p); err != nil {
+			_ = c.Close()
+			delete(h.clients, c)
+		}
+	}
+}
+
+func (h *Host) acceptLoop() {
+	for {
+		conn, err := h.ln.Accept()
+		if err != nil {
+			return
+		}
+		h.mu.Lock()
+		h.clients[conn] = &clientState{}
+		h.mu.Unlock()
+		go h.serve(conn)
+	}
+}
+
+func (h *Host) serve(conn net.Conn) {
+	defer func() {
+		h.mu.Lock()
+		delete(h.clients, conn)
+		h.mu.Unlock()
+		_ = conn.Close()
+		h.recomputeSize()
+	}()
+	for {
+		typ, payload, err := readFrame(conn)
+		if err != nil {
+			return
+		}
+		switch typ {
+		case FrameInput:
+			if h.inputOK {
+				_, _ = h.inW.Write(payload)
+			}
+		case FrameResize:
+			if len(payload) == 4 {
+				h.mu.Lock()
+				h.clients[conn].size = winsize{
+					rows: uint16(payload[0])<<8 | uint16(payload[1]),
+					cols: uint16(payload[2])<<8 | uint16(payload[3]),
+				}
+				h.mu.Unlock()
+				h.recomputeSize()
+			}
+		case FramePing:
+			_ = writeFrame(conn, FramePing, nil)
+		}
+	}
+}
+
+// recomputeSize applies the tmux rule: smallest declared participant
+// wins, so no viewer sees a clipped frame.
+func (h *Host) recomputeSize() {
+	h.mu.Lock()
+	eff := h.local
+	for _, c := range h.clients {
+		if c.size.rows == 0 || c.size.cols == 0 {
+			continue
+		}
+		if eff.rows == 0 || c.size.rows < eff.rows {
+			eff.rows = c.size.rows
+		}
+		if eff.cols == 0 || c.size.cols < eff.cols {
+			eff.cols = c.size.cols
+		}
+	}
+	h.mu.Unlock()
+	if eff.rows == 0 {
+		return
+	}
+	_ = windows.ResizePseudoConsole(h.hpc, windows.Coord{X: int16(eff.cols), Y: int16(eff.rows)})
+}
+
+// Close tears the socket and ConPTY down.
+func (h *Host) Close() {
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return
+	}
+	h.closed = true
+	for c := range h.clients {
+		_ = c.Close()
+	}
+	h.mu.Unlock()
+	if h.ln != nil {
+		_ = h.ln.Close()
+	}
+	_ = os.Remove(h.sockPath)
+	if h.hpc != 0 {
+		windows.ClosePseudoConsole(h.hpc)
+	}
+	if h.inW != nil {
+		_ = h.inW.Close()
+	}
+	if h.outR != nil {
+		_ = h.outR.Close()
+	}
+}
+
+// StartAttached launches claude attached to this ConPTY and returns a
+// child the wrapper can wait on / signal. Each launch gets a fresh
+// process on the same console, so attached viewers ride through account
+// swaps just like on Unix.
+func (h *Host) StartAttached(claudeBin string, argv, env []string) (*winChild, error) {
+	// Build the command line: "bin" arg1 arg2 … (quoted).
+	parts := make([]string, 0, len(argv)+1)
+	parts = append(parts, quoteArg(claudeBin))
+	for _, a := range argv {
+		parts = append(parts, quoteArg(a))
+	}
+	cmdline, err := windows.UTF16PtrFromString(strings.Join(parts, " "))
+	if err != nil {
+		return nil, err
+	}
+
+	// STARTUPINFOEX carrying the pseudo-console attribute.
+	attrList, err := windows.NewProcThreadAttributeList(1)
+	if err != nil {
+		return nil, err
+	}
+	defer attrList.Delete()
+	if err := attrList.Update(
+		procThreadAttributePseudoConsole,
+		unsafe.Pointer(h.hpc),
+		unsafe.Sizeof(h.hpc),
+	); err != nil {
+		return nil, err
+	}
+
+	var si windows.StartupInfoEx
+	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
+	si.ProcThreadAttributeList = attrList.List()
+
+	var pi windows.ProcessInformation
+	flags := uint32(windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_UNICODE_ENVIRONMENT)
+	if err := windows.CreateProcess(
+		nil, cmdline, nil, nil, false, flags,
+		envBlock(env), nil, &si.StartupInfo, &pi,
+	); err != nil {
+		return nil, err
+	}
+	windows.CloseHandle(pi.Thread)
+	return &winChild{proc: pi.Process, pid: int(pi.ProcessId), host: h}, nil
+}
+
+// envBlock turns "K=V" strings into a UTF-16, double-null-terminated
+// environment block for CreateProcess.
+func envBlock(env []string) *uint16 {
+	var b []uint16
+	for _, e := range env {
+		u, err := windows.UTF16FromString(e)
+		if err != nil {
+			continue
+		}
+		b = append(b, u...) // u is already NUL-terminated
+	}
+	b = append(b, 0) // final NUL → double-NUL terminator
+	return &b[0]
+}
+
+// quoteArg applies minimal CommandLineToArgv-compatible quoting.
+func quoteArg(s string) string {
+	if s != "" && !strings.ContainsAny(s, " \t\"") {
+		return s
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	slashes := 0
+	for _, r := range s {
+		switch r {
+		case '\\':
+			slashes++
+		case '"':
+			for i := 0; i < slashes*2+1; i++ {
+				b.WriteByte('\\')
+			}
+			slashes = 0
+			b.WriteByte('"')
+			continue
+		default:
+			slashes = 0
+		}
+		b.WriteRune(r)
+	}
+	for i := 0; i < slashes*2; i++ {
+		b.WriteByte('\\')
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// winChild is a ConPTY-attached claude process, satisfying wrapper.child.
+type winChild struct {
+	proc   windows.Handle
+	pid    int
+	host   *Host
+	exited atomic.Bool
+}
+
+func (c *winChild) Pid() int { return c.pid }
+
+// Signal maps os.Interrupt to a Ctrl-C byte written into the console —
+// ConPTY delivers it to the child as a real ^C. Other signals are no-ops
+// (Windows has no general kill-by-signal for another process group here).
+func (c *winChild) Signal(os.Signal) error {
+	_, err := c.host.inW.Write([]byte{0x03})
+	return err
+}
+
+func (c *winChild) Kill() error { return windows.TerminateProcess(c.proc, 1) }
+
+func (c *winChild) Exited() bool { return c.exited.Load() }
+
+func (c *winChild) Wait() error {
+	_, err := windows.WaitForSingleObject(c.proc, windows.INFINITE)
+	c.exited.Store(true)
+	if err != nil {
+		windows.CloseHandle(c.proc)
+		return err
+	}
+	var code uint32
+	_ = windows.GetExitCodeProcess(c.proc, &code)
+	windows.CloseHandle(c.proc)
+	if code != 0 {
+		return &exitError{code: int(code)}
+	}
+	return nil
+}
+
+// exitError mirrors *exec.ExitError enough for the wrapper's ExitCode
+// handling (errors.As on *exec.ExitError won't match, but the wrapper
+// only reads the code via its own path on Unix; on Windows a non-zero
+// exit returns this and the loop treats it as a normal exit code).
+type exitError struct{ code int }
+
+func (e *exitError) Error() string { return "exit status " + itoa(e.code) }
+func (e *exitError) ExitCode() int { return e.code }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}

--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -31,7 +31,10 @@ const procThreadAttributePseudoConsole = 0x00020016
 
 type winsize struct{ rows, cols uint16 }
 
-type clientState struct{ size winsize }
+type clientState struct {
+	size winsize
+	wmu  sync.Mutex // serializes writes to this client's conn (replay, broadcast, ping)
+}
 
 // Host owns the ConPTY and the attach socket for one wrapper.
 type Host struct {
@@ -150,14 +153,38 @@ type broadcastWriter struct{ h *Host }
 
 func (b broadcastWriter) Write(p []byte) (int, error) { b.h.broadcast(p); return len(p), nil }
 
+// writeClient sends one frame to a client, serialized with every other
+// write to the same conn via its clientState.wmu — writeFrame emits a
+// header then a payload as two writes, so without this lock a broadcast
+// could interleave between another writer's header and payload and corrupt
+// the stream. On error the client is dropped.
+func (h *Host) writeClient(conn net.Conn, cs *clientState, typ byte, p []byte) {
+	cs.wmu.Lock()
+	err := writeFrame(conn, typ, p)
+	cs.wmu.Unlock()
+	if err != nil {
+		h.mu.Lock()
+		delete(h.clients, conn)
+		h.mu.Unlock()
+		_ = conn.Close()
+	}
+}
+
 func (h *Host) broadcast(p []byte) {
+	// Snapshot the client set, then write outside h.mu so one slow client
+	// can't stall the whole broadcast (or block accept) while holding it.
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	for c := range h.clients {
-		if err := writeFrame(c, FrameOut, p); err != nil {
-			_ = c.Close()
-			delete(h.clients, c)
-		}
+	type ref struct {
+		conn net.Conn
+		cs   *clientState
+	}
+	refs := make([]ref, 0, len(h.clients))
+	for c, cs := range h.clients {
+		refs = append(refs, ref{c, cs})
+	}
+	h.mu.Unlock()
+	for _, r := range refs {
+		h.writeClient(r.conn, r.cs, FrameOut, p)
 	}
 }
 
@@ -167,18 +194,27 @@ func (h *Host) acceptLoop() {
 		if err != nil {
 			return
 		}
+		cs := &clientState{}
+		// Hold the client's write lock across registration and replay so
+		// the backlog is the first thing written to this conn: any
+		// broadcast that races the new client blocks on wmu until the
+		// replay is out, keeping scrollback strictly before live output.
+		cs.wmu.Lock()
 		h.mu.Lock()
-		h.clients[conn] = &clientState{}
+		h.clients[conn] = cs
+		replay := h.hist.replay()
 		h.mu.Unlock()
-		go h.serve(conn)
+		if len(replay) > 0 {
+			_ = writeFrame(conn, FrameOut, replay)
+		}
+		cs.wmu.Unlock()
+		go h.serve(conn, cs)
 	}
 }
 
-func (h *Host) serve(conn net.Conn) {
-	// Replay the recent-output backlog so the client has scrollback.
-	if b := h.hist.snapshot(); len(b) > 0 {
-		_ = writeFrame(conn, FrameOut, b)
-	}
+// serve reads one client's frames until it disconnects. The backlog replay
+// (scrollback) already went out in acceptLoop; here we only read.
+func (h *Host) serve(conn net.Conn, cs *clientState) {
 	defer func() {
 		h.mu.Lock()
 		delete(h.clients, conn)
@@ -199,7 +235,7 @@ func (h *Host) serve(conn net.Conn) {
 		case FrameResize:
 			if len(payload) == 4 {
 				h.mu.Lock()
-				h.clients[conn].size = winsize{
+				cs.size = winsize{
 					rows: uint16(payload[0])<<8 | uint16(payload[1]),
 					cols: uint16(payload[2])<<8 | uint16(payload[3]),
 				}
@@ -207,15 +243,22 @@ func (h *Host) serve(conn net.Conn) {
 				h.recomputeSize()
 			}
 		case FramePing:
-			_ = writeFrame(conn, FramePing, nil)
+			h.writeClient(conn, cs, FramePing, nil)
 		}
 	}
 }
 
 // recomputeSize applies the tmux rule: smallest declared participant
 // wins, so no viewer sees a clipped frame.
+// recomputeSize holds h.mu across the ConPTY resize so it can't race
+// Close() destroying the pseudo-console; the closed guard makes it a
+// no-op once torn down.
 func (h *Host) recomputeSize() {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	eff := h.local
 	for _, c := range h.clients {
 		if c.size.rows == 0 || c.size.cols == 0 {
@@ -228,7 +271,6 @@ func (h *Host) recomputeSize() {
 			eff.cols = c.size.cols
 		}
 	}
-	h.mu.Unlock()
 	if eff.rows == 0 {
 		return
 	}
@@ -246,14 +288,15 @@ func (h *Host) Close() {
 	for c := range h.clients {
 		_ = c.Close()
 	}
+	// Destroy the console under h.mu so it can't race an in-flight resize.
+	if h.hpc != 0 {
+		windows.ClosePseudoConsole(h.hpc)
+	}
 	h.mu.Unlock()
 	if h.ln != nil {
 		_ = h.ln.Close()
 	}
 	_ = os.Remove(h.sockPath)
-	if h.hpc != 0 {
-		windows.ClosePseudoConsole(h.hpc)
-	}
 	if h.inW != nil {
 		_ = h.inW.Close()
 	}

--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -47,6 +47,7 @@ type Host struct {
 	clients map[net.Conn]*clientState
 	local   winsize
 	closed  bool
+	hist    history // recent output, replayed to new clients for scrollback
 }
 
 // New creates the ConPTY (sized to the current console), keeps the host
@@ -133,6 +134,7 @@ func (h *Host) Pump() {
 	for {
 		n, err := h.outR.Read(buf)
 		if n > 0 {
+			h.hist.record(buf[:n])
 			_, _ = os.Stdout.Write(buf[:n])
 			h.broadcast(buf[:n])
 		}
@@ -173,6 +175,10 @@ func (h *Host) acceptLoop() {
 }
 
 func (h *Host) serve(conn net.Conn) {
+	// Replay the recent-output backlog so the client has scrollback.
+	if b := h.hist.snapshot(); len(b) > 0 {
+		_ = writeFrame(conn, FrameOut, b)
+	}
 	defer func() {
 		h.mu.Lock()
 		delete(h.clients, conn)

--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -170,6 +170,11 @@ func (h *Host) writeClient(conn net.Conn, cs *clientState, typ byte, p []byte) {
 	}
 }
 
+// SetChildPID is a no-op on Windows: ResizePseudoConsole notifies the
+// attached process of size changes itself, so there is no out-of-band
+// signal to deliver as there is on Unix. Present for API parity.
+func (h *Host) SetChildPID(pid int) {}
+
 func (h *Host) broadcast(p []byte) {
 	// Snapshot the client set, then write outside h.mu so one slow client
 	// can't stall the whole broadcast (or block accept) while holding it.

--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -24,6 +24,7 @@ type Host struct{}
 
 func New(sockPath string, inputOK bool) (*Host, error)       { return nil, ErrUnsupported }
 func (h *Host) TTY() *os.File                                { return nil }
+func (h *Host) TTYDup() (*os.File, error)                    { return nil, ErrUnsupported }
 func (h *Host) Pump()                                        {}
 func (h *Host) BroadcastWriter() io.Writer                   { return io.Discard }
 func (h *Host) Close()                                       {}

--- a/internal/ptyhost/ptyhost_windows_test.go
+++ b/internal/ptyhost/ptyhost_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package ptyhost
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestConPTYRelaunch is the Windows counterpart to the Unix relaunch
+// test: three back-to-back children on one ConPTY (the rate-limit swap
+// path) must all start, run, and exit — the master (Pump) stays alive
+// because the ConPTY outlives individual processes.
+func TestConPTYRelaunch(t *testing.T) {
+	h, err := New(filepath.Join(t.TempDir(), "s.sock"), true)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+	go h.Pump()
+	for i := 0; i < 3; i++ {
+		ch, err := h.StartAttached(`C:\windows\system32\cmd.exe`, []string{"/c", "echo ok"}, os.Environ())
+		if err != nil {
+			t.Fatalf("launch %d: start: %v", i, err)
+		}
+		if err := ch.Wait(); err != nil {
+			t.Fatalf("launch %d: wait: %v", i, err)
+		}
+	}
+}

--- a/internal/ptyhost/relaunch_test.go
+++ b/internal/ptyhost/relaunch_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package ptyhost
 
 import (

--- a/internal/ptyhost/relaunch_test.go
+++ b/internal/ptyhost/relaunch_test.go
@@ -1,0 +1,39 @@
+package ptyhost
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestRelaunchReusesTTY reproduces the wrapper's relaunch path: the same
+// Host (and thus the same tty) is wired into a second exec.Cmd after the
+// first child has exited. The reported bug was the second Start failing
+// with "bad file descriptor".
+func TestRelaunchReusesTTY(t *testing.T) {
+	h, err := New(filepath.Join(t.TempDir(), "s.sock"), false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+
+	for i := 0; i < 3; i++ {
+		cmd := exec.Command("true")
+		// Mirror the wrapper's launch(): a fresh dup per exec, so os/exec's
+		// Wait() closing its stdio doesn't take down the shared PTY slave.
+		tty, err := h.TTYDup()
+		if err != nil {
+			t.Fatalf("launch %d: dup: %v", i, err)
+		}
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+		cmd.SysProcAttr = SysProcAttr()
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("launch %d: start: %v", i, err)
+		}
+		_ = cmd.Wait()
+	}
+	// The real slave must still be usable after all those launches.
+	if _, err := h.TTYDup(); err != nil {
+		t.Fatalf("PTY slave was closed by a child's exec: %v", err)
+	}
+}

--- a/internal/ptyhost/resize_signal_test.go
+++ b/internal/ptyhost/resize_signal_test.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+package ptyhost
+
+import (
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestResizeSignalsChild verifies that a size change delivers SIGWINCH to
+// the registered child. claude runs without a controlling terminal, so a
+// TIOCSWINSZ on the master raises no SIGWINCH by itself — the host must
+// signal the child explicitly or the child never reflows to the new size.
+func TestResizeSignalsChild(t *testing.T) {
+	h, err := New(filepath.Join(t.TempDir(), "s.sock"), true)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+
+	sig := make(chan os.Signal, 8)
+	signal.Notify(sig, syscall.SIGWINCH)
+	defer signal.Stop(sig)
+	// Drain any SIGWINCH already queued from construction.
+	for draining := true; draining; {
+		select {
+		case <-sig:
+		default:
+			draining = false
+		}
+	}
+
+	// Register this test process as the child, then change the size.
+	h.SetChildPID(os.Getpid())
+	h.applySize()
+
+	select {
+	case <-sig:
+		// delivered — good
+	case <-time.After(2 * time.Second):
+		t.Fatal("resize did not deliver SIGWINCH to the child")
+	}
+
+	// After clearing the child, a resize must not signal anyone.
+	h.SetChildPID(0)
+	for draining := true; draining; {
+		select {
+		case <-sig:
+		default:
+			draining = false
+		}
+	}
+	h.applySize()
+	select {
+	case <-sig:
+		t.Fatal("resize signaled after the child was cleared")
+	case <-time.After(300 * time.Millisecond):
+		// no signal — good
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -35,14 +35,15 @@ const (
 
 // Entry is one running wrapper's self-reported status.
 type Entry struct {
-	PID       int       `json:"pid"`
-	CWD       string    `json:"cwd"`
-	SessionID string    `json:"sessionId,omitempty"`
-	Seat      string    `json:"seat,omitempty"` // email claude was last launched on
-	State     string    `json:"state"`
-	Detail    string    `json:"detail,omitempty"` // human hint: "reset in 1h23m", "attempt 3"
-	StartedAt time.Time `json:"startedAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	PID        int       `json:"pid"`
+	CWD        string    `json:"cwd"`
+	SessionID  string    `json:"sessionId,omitempty"`
+	Seat       string    `json:"seat,omitempty"` // email claude was last launched on
+	State      string    `json:"state"`
+	Attachable bool      `json:"attachable,omitempty"` // wrapper serves an attach socket
+	Detail     string    `json:"detail,omitempty"`     // human hint: "reset in 1h23m", "attempt 3"
+	StartedAt  time.Time `json:"startedAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
 }
 
 func dir() string { return filepath.Join(paths.RuntimeDir(), "sessions") }

--- a/internal/wrapper/child.go
+++ b/internal/wrapper/child.go
@@ -1,0 +1,52 @@
+package wrapper
+
+import (
+	"os"
+	"os/exec"
+)
+
+// child is the running claude process as launch() needs to drive it. It
+// exists so the Windows ConPTY path — which can't go through os/exec —
+// can plug in beside the Unix os/exec path without the swap/poll/wait
+// logic knowing which one it's talking to.
+type child interface {
+	// Pid is the OS process id (0 before start / after reap).
+	Pid() int
+	// Signal asks the process to exit (os.Interrupt for a graceful stop).
+	Signal(os.Signal) error
+	// Kill force-terminates the process.
+	Kill() error
+	// Exited reports whether the process has been reaped (Wait returned).
+	Exited() bool
+	// Wait blocks until the process exits and returns its wait error
+	// (an *exec.ExitError for a non-zero exit).
+	Wait() error
+}
+
+// execChild is the Unix (and non-attach) child: a plain os/exec process.
+type execChild struct{ cmd *exec.Cmd }
+
+func (c *execChild) Pid() int {
+	if c.cmd.Process == nil {
+		return 0
+	}
+	return c.cmd.Process.Pid
+}
+
+func (c *execChild) Signal(s os.Signal) error {
+	if c.cmd.Process == nil {
+		return nil
+	}
+	return c.cmd.Process.Signal(s)
+}
+
+func (c *execChild) Kill() error {
+	if c.cmd.Process == nil {
+		return nil
+	}
+	return c.cmd.Process.Kill()
+}
+
+func (c *execChild) Exited() bool { return c.cmd.ProcessState != nil }
+
+func (c *execChild) Wait() error { return c.cmd.Wait() }

--- a/internal/wrapper/proctree_test.go
+++ b/internal/wrapper/proctree_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package wrapper
 
 import (

--- a/internal/wrapper/proctree_test.go
+++ b/internal/wrapper/proctree_test.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package wrapper
 
 import (

--- a/internal/wrapper/start_other.go
+++ b/internal/wrapper/start_other.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package wrapper
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/inulute/cux/internal/ptyhost"
+)
+
+// startChild launches claude. With an attach host it runs on a fresh PTY
+// slave (dup per launch — see ptyhost.TTYDup) as its controlling
+// terminal; otherwise it inherits the wrapper's stdio.
+func startChild(claudeBin string, argv, env []string, host *ptyhost.Host) (child, error) {
+	cmd := exec.Command(claudeBin, argv...)
+	if host != nil {
+		tty, err := host.TTYDup()
+		if err != nil {
+			return nil, fmt.Errorf("dup pty slave: %w", err)
+		}
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+		cmd.SysProcAttr = ptyhost.SysProcAttr()
+	} else {
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	}
+	cmd.Env = env
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &execChild{cmd: cmd}, nil
+}

--- a/internal/wrapper/start_windows.go
+++ b/internal/wrapper/start_windows.go
@@ -9,10 +9,13 @@ import (
 	"github.com/inulute/cux/internal/ptyhost"
 )
 
-// startChild launches claude on Windows. The ConPTY attach path is wired
-// in once ptyhost_windows.go grows a real implementation; until then the
-// host is always nil and the child inherits the wrapper's stdio.
+// startChild launches claude on Windows. With an attach host it runs on
+// the host's ConPTY (os/exec can't attach one, so the host owns the
+// spawn); otherwise it inherits the wrapper's stdio.
 func startChild(claudeBin string, argv, env []string, host *ptyhost.Host) (child, error) {
+	if host != nil {
+		return host.StartAttached(claudeBin, argv, env)
+	}
 	cmd := exec.Command(claudeBin, argv...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Env = env

--- a/internal/wrapper/start_windows.go
+++ b/internal/wrapper/start_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package wrapper
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/inulute/cux/internal/ptyhost"
+)
+
+// startChild launches claude on Windows. The ConPTY attach path is wired
+// in once ptyhost_windows.go grows a real implementation; until then the
+// host is always nil and the child inherits the wrapper's stdio.
+func startChild(claudeBin string, argv, env []string, host *ptyhost.Host) (child, error) {
+	cmd := exec.Command(claudeBin, argv...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.Env = env
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &execChild{cmd: cmd}, nil
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -396,29 +396,15 @@ func setManualSwitchState(email string) {
 // whether at least one turn completed (Stop signal fired), and a non-nil
 // pending struct if the wrapper has decided to swap.
 func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config, manualTarget string, host *ptyhost.Host, w io.Writer) (int, string, bool, *pending, error) {
-	cmd := exec.Command(claudeBin, argv...)
-	if host != nil {
-		// A dup per launch: os/exec's Wait() closes the stdio files it's
-		// handed, so the shared PTY slave must not be wired in directly —
-		// otherwise the next relaunch (e.g. after a rate-limit account
-		// swap) fails with "bad file descriptor". exec owns and closes
-		// this dup; the real slave lives on with the Host.
-		tty, err := host.TTYDup()
-		if err != nil {
-			return 1, "", false, nil, fmt.Errorf("wrapper: dup pty slave: %w", err)
-		}
-		cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
-		cmd.SysProcAttr = ptyhost.SysProcAttr()
-	} else {
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-	}
-	cmd.Env = append(os.Environ(),
+	env := append(os.Environ(),
 		envWrapped+"=1",
 		envWrapperPID+"="+strconv.Itoa(wrapperPID),
 	)
-	if err := cmd.Start(); err != nil {
+	// startChild is platform-specific: Unix runs claude on a PTY slave
+	// (see start_other.go), Windows on a ConPTY (start_windows.go). The
+	// swap/poll/wait logic below drives it through the `child` interface.
+	ch, err := startChild(claudeBin, argv, env, host)
+	if err != nil {
 		return 1, "", false, nil, fmt.Errorf("wrapper: start claude: %w", err)
 	}
 
@@ -443,12 +429,12 @@ func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config,
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				step(wrapperPID, cfg, manualTarget, &mu, &sessionID, &swap, &stopRequested, &hadTurns, cmd, w)
+				step(wrapperPID, cfg, manualTarget, &mu, &sessionID, &swap, &stopRequested, &hadTurns, ch, w)
 			}
 		}
 	}()
 
-	waitErr := cmd.Wait()
+	waitErr := ch.Wait()
 	cancel()
 	<-pollDone
 
@@ -492,7 +478,7 @@ func step(
 	swap **pending,
 	stopRequested *atomic.Bool,
 	hadTurns *atomic.Bool,
-	cmd *exec.Cmd,
+	ch child,
 	w io.Writer,
 ) {
 	// 1. Capture session-started if we haven't yet.
@@ -526,7 +512,7 @@ func step(
 			hasSwap = *swap != nil
 			mu.Unlock()
 			if hasSwap && stopRequested.CompareAndSwap(false, true) {
-				go gracefulExit(cmd, w)
+				go gracefulExit(ch, w)
 				return
 			}
 		} else {
@@ -553,7 +539,7 @@ func step(
 			hasSwap = *swap != nil
 			mu.Unlock()
 			if hasSwap && stopRequested.CompareAndSwap(false, true) {
-				go gracefulExit(cmd, w)
+				go gracefulExit(ch, w)
 				return
 			}
 		}
@@ -583,7 +569,7 @@ func step(
 		hasSwap = *swap != nil
 		mu.Unlock()
 		if hasSwap && stopRequested.CompareAndSwap(false, true) {
-			go gracefulExit(cmd, w)
+			go gracefulExit(ch, w)
 			return
 		}
 	}
@@ -616,7 +602,7 @@ func step(
 		hasSwap := *swap != nil
 		mu.Unlock()
 		if hasSwap && stopRequested.CompareAndSwap(false, true) {
-			go gracefulExit(cmd, w)
+			go gracefulExit(ch, w)
 			return
 		}
 	}
@@ -984,8 +970,9 @@ func shortDuration(d time.Duration) string {
 // transcript is usually flushed. Rate-limit and manual /switch paths
 // may interrupt mid-turn; Run waits for the transcript file to settle
 // before relaunching with --resume.
-func gracefulExit(cmd *exec.Cmd, w io.Writer) {
-	if cmd.Process == nil {
+func gracefulExit(ch child, w io.Writer) {
+	pid := ch.Pid()
+	if pid == 0 {
 		return
 	}
 	// Snapshot the descendant tree before signalling: claudeBin may be
@@ -994,8 +981,8 @@ func gracefulExit(cmd *exec.Cmd, w io.Writer) {
 	// dying shell does not forward it — grandchildren would survive,
 	// stay attached to the terminal, and fight the relaunched claude
 	// for stdin.
-	strays := descendantPIDs(cmd.Process.Pid)
-	_ = cmd.Process.Signal(os.Interrupt)
+	strays := descendantPIDs(pid)
+	_ = ch.Signal(os.Interrupt)
 
 	deadline := time.NewTimer(gracefulExitWait)
 	defer deadline.Stop()
@@ -1006,11 +993,11 @@ func gracefulExit(cmd *exec.Cmd, w io.Writer) {
 		select {
 		case <-deadline.C:
 			fmt.Fprintln(w, "cux: claude did not exit cleanly, terminating…")
-			_ = cmd.Process.Kill()
+			_ = ch.Kill()
 			reapStrays(strays, w)
 			return
 		case <-tick.C:
-			if cmd.ProcessState != nil {
+			if ch.Exited() {
 				reapStrays(strays, w)
 				return
 			}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -19,6 +19,7 @@
 package wrapper
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -37,12 +38,14 @@ import (
 	"github.com/inulute/cux/internal/history"
 	"github.com/inulute/cux/internal/monitor"
 	"github.com/inulute/cux/internal/paths"
+	"github.com/inulute/cux/internal/ptyhost"
 	"github.com/inulute/cux/internal/registry"
 	"github.com/inulute/cux/internal/signals"
 	"github.com/inulute/cux/internal/store"
 	"github.com/inulute/cux/internal/strategy"
 	"github.com/inulute/cux/internal/switcher"
 	"github.com/inulute/cux/internal/usage"
+	"golang.org/x/term"
 )
 
 const (
@@ -57,6 +60,18 @@ const (
 	transcriptPollInterval = 50 * time.Millisecond
 	resumeRetryExtraWait   = 500 * time.Millisecond
 )
+
+// crlfWriter translates \n to \r\n so wrapper narration renders
+// correctly while the terminal is in raw mode for the PTY host.
+type crlfWriter struct{ w io.Writer }
+
+func (c crlfWriter) Write(p []byte) (int, error) {
+	out := bytes.ReplaceAll(p, []byte("\n"), []byte("\r\n"))
+	if _, err := c.w.Write(out); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
 
 // pending captures the reason the wrapper has decided a swap is needed.
 // trigger is the user-facing label that ends up in the swap history;
@@ -99,6 +114,30 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 	// can show every concurrent session at a glance.
 	registry.UpdateSelf(func(e *registry.Entry) { e.State = registry.StateRunning })
 	defer registry.RemoveSelf()
+
+	// Attachable sessions: when stdin is a real terminal, run claude on
+	// a wrapper-owned PTY and serve mirrors on a Unix socket. The PTY
+	// outlives individual claude launches, so attached viewers ride
+	// straight through account swaps. Non-TTY stdin (pipes, CI) keeps
+	// the plain inherit-stdio path untouched.
+	var host *ptyhost.Host
+	if cfg.Attach && term.IsTerminal(int(os.Stdin.Fd())) {
+		_ = os.MkdirAll(paths.AttachDir(), 0o700)
+		if h, err := ptyhost.New(paths.AttachSock(pid), cfg.AttachInput); err == nil {
+			host = h
+			defer host.Close()
+			if old, rawErr := term.MakeRaw(int(os.Stdin.Fd())); rawErr == nil {
+				defer func() { _ = term.Restore(int(os.Stdin.Fd()), old) }()
+			}
+			go host.Pump()
+			// Wrapper narration ("cux: …" lines) goes to the real
+			// terminal (raw mode needs CRLF) and to attached viewers.
+			w = io.MultiWriter(crlfWriter{os.Stdout}, host.BroadcastWriter())
+			registry.UpdateSelf(func(e *registry.Entry) { e.Attachable = true })
+		} else {
+			fmt.Fprintf(w, "cux: attach disabled: %v\n", err)
+		}
+	}
 
 	// lastManualTarget holds the email the user explicitly switched to
 	// within this wrapper session. Threshold auto-switch is suppressed
@@ -146,7 +185,7 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 				e.Detail = ""
 			})
 		}
-		exitCode, sessionID, hadTurns, p, err := launch(claudeBin, currentArgv, pid, &cfg, lastManualTarget, w)
+		exitCode, sessionID, hadTurns, p, err := launch(claudeBin, currentArgv, pid, &cfg, lastManualTarget, host, w)
 		if err != nil {
 			return exitCode, err
 		}
@@ -356,11 +395,17 @@ func setManualSwitchState(email string) {
 // Returns the child's exit code, the session_id we observed (if any),
 // whether at least one turn completed (Stop signal fired), and a non-nil
 // pending struct if the wrapper has decided to swap.
-func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config, manualTarget string, w io.Writer) (int, string, bool, *pending, error) {
+func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config, manualTarget string, host *ptyhost.Host, w io.Writer) (int, string, bool, *pending, error) {
 	cmd := exec.Command(claudeBin, argv...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if host != nil {
+		tty := host.TTY()
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+		cmd.SysProcAttr = ptyhost.SysProcAttr()
+	} else {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	cmd.Env = append(os.Environ(),
 		envWrapped+"=1",
 		envWrapperPID+"="+strconv.Itoa(wrapperPID),

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -407,6 +407,13 @@ func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config,
 	if err != nil {
 		return 1, "", false, nil, fmt.Errorf("wrapper: start claude: %w", err)
 	}
+	// Tell the host which process to nudge with SIGWINCH on resize: the
+	// child runs without a controlling terminal, so a PTY size change does
+	// not raise SIGWINCH on its own. Refreshed on every (re)launch.
+	if host != nil {
+		host.SetChildPID(ch.Pid())
+		defer host.SetChildPID(0)
+	}
 
 	var (
 		mu        sync.Mutex

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -398,7 +398,15 @@ func setManualSwitchState(email string) {
 func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config, manualTarget string, host *ptyhost.Host, w io.Writer) (int, string, bool, *pending, error) {
 	cmd := exec.Command(claudeBin, argv...)
 	if host != nil {
-		tty := host.TTY()
+		// A dup per launch: os/exec's Wait() closes the stdio files it's
+		// handed, so the shared PTY slave must not be wired in directly —
+		// otherwise the next relaunch (e.g. after a rate-limit account
+		// swap) fails with "bad file descriptor". exec owns and closes
+		// this dup; the real slave lives on with the Host.
+		tty, err := host.TTYDup()
+		if err != nil {
+			return 1, "", false, nil, fmt.Errorf("wrapper: dup pty slave: %w", err)
+		}
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
 		cmd.SysProcAttr = ptyhost.SysProcAttr()
 	} else {

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestResolveTargetDoesNotRotateToWeeklyFullFallback(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	t.Setenv("CUX_CREDS_BACKEND", "file")
 
@@ -82,6 +83,7 @@ func TestEvaluatePrelaunchHardLimitSwapUsesRateLimitTrigger(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("CUX_CREDS_BACKEND", "file")
 	claudeDir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
@@ -138,6 +140,7 @@ func TestEvaluatePrelaunchHardLimitSwapBlocksWhenAllAccountsFull(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("CUX_CREDS_BACKEND", "file")
 	claudeDir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
@@ -212,6 +215,7 @@ func TestResumeSessionID(t *testing.T) {
 func TestWaitForTranscriptStableFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	cwd := filepath.Join(home, "proj")
 	if err := os.MkdirAll(cwd, 0o700); err != nil {
 		t.Fatal(err)
@@ -232,6 +236,7 @@ func TestWaitForTranscriptStableFile(t *testing.T) {
 func TestWaitForTranscriptEventuallyStable(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	cwd := filepath.Join(home, "proj")
 	if err := os.MkdirAll(cwd, 0o700); err != nil {
 		t.Fatal(err)
@@ -260,6 +265,7 @@ func TestWaitForTranscriptEventuallyStable(t *testing.T) {
 func TestWaitForTranscriptMissing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	cwd := filepath.Join(home, "proj")
 	if err := os.MkdirAll(cwd, 0o700); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What

`cux attach [pid]` — attach any terminal to a running cux session, tmux-style, with zero external dependencies. The wrapper runs claude on a PTY it owns and serves mirrors on a Unix socket; any number of clients can watch the live terminal and (optionally) type into it — keystrokes, Ctrl+C, everything. **Now on Windows too, via ConPTY.**

## Why

cux's whole promise is sessions that outlive your attention span: overnight runs, multiple terminals, multiple machines. Today the only way to *see* one of those sessions is to be the terminal that started it. Attachable sessions close that gap, and they also give remote surfaces (dashboards, phones — anything that can reach the socket through a bridge) a real terminal, not a scrape.

## How

The dtach model, in-process — the wrapper already sits between the user and claude, so the PTY interposition is one hop:

```
user terminal ⇄ wrapper (raw mode) ⇄ PTY/ConPTY ⇄ claude
                        ⇅
        ~/.cux/runtime/attach/<pid>.sock  ⇄  cux attach / bridges
```

- **The PTY belongs to the wrapper, not the claude child** — it survives the kill+resume relaunches cux performs on account swaps. Attached viewers ride straight through a seat change without reconnecting.
- **5-byte framed protocol** on the socket (`out` / `input` / `resize` / `ping`), in a build-tag-free `frame.go` shared by both platform hosts and `cux attach`. Socket is 0600.
- **Clean frame on attach without host-side terminal emulation:** the host nudges the PTY one row smaller and back; full-screen programs (claude included) repaint on SIGWINCH. This is dtach's `-r winch` trick. (Unix; ConPTY repaints on resize on its own.)
- **Size arbitration:** smallest declared participant wins (the tmux rule), so no viewer sees a clipped frame.
- **Config:** `attach` / `attach_input`, both default `true`; set `attach_input: false` for view-only mirrors. Non-TTY stdin (pipes, CI) keeps the old inherit-stdio path untouched.
- **`cux sessions`** integration: registry entries gain `attachable`; `cux attach` with no argument picks the only attachable session; `Ctrl+\` detaches.

### Windows (ConPTY)

`ptyhost_windows.go` is now a real host, not a stub. `New` creates a pseudo-console (`CreatePseudoConsole`) with its own input/output pipes; `StartAttached` spawns claude attached to it with `CreateProcess` + a `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` `STARTUPINFOEX`, returning the same `child` the wrapper drives everywhere else (Ctrl-C is a `0x03` into the console; `Wait`/`Kill` go through the process handle). The socket + frame layer is shared with Unix. Because the ConPTY outlives individual children, relaunches keep working — and the attach socket is best-effort, so on a runtime without `AF_UNIX` the session still runs, just unmirrored.

### Relaunch durability

Making the PTY outlive claude means the relaunch path (rate-limit account swaps → resume) has to be airtight. Three issues surfaced and are fixed here, each with a regression test:

- **`os/exec` closes the stdio it's handed on `Wait`** — wiring the shared slave in directly meant the second launch got a closed fd (`fork/exec … bad file descriptor`). Fixed by opening a fresh slave handle per launch (`TTYDup`).
- **`Setctty` made claude the slave's session leader**, so its exit revoked the controlling terminal and hit the shared master as EOF, killing `Pump()` — the next resume then wrote into a master nobody read and hung at "resuming on …". Dropped `Setctty`; `Setsid` alone is enough (claude still sees a real tty, Ctrl-C/input arrive as PTY bytes).
- **Process launch is abstracted behind a small `child` interface**, so the Windows ConPTY path plugs in without the swap/poll/wait logic knowing which backend it drives.

## Verification

| Scenario | Result |
|---|---|
| Remote typing / `Ctrl+C` over the socket | echoes through the PTY into the child ✓ |
| Two simultaneous viewers | same output stream ✓ |
| View-only host (`attach_input: false`) | client keystrokes dropped ✓ (unit test) |
| Relaunch (3 back-to-back launches on one host) | all start & exit; master stays alive ✓ (Unix + Windows tests) |
| **Windows ConPTY** — process attach, I/O, relaunch | verified on a real Windows runtime ✓ |
| Non-TTY stdin | PTY host skipped; existing path unchanged |

Unix and Windows both build and test green; unix-only test files are `//go:build !windows` so the package compiles for `GOOS=windows`. Happy to split this differently or adjust flag defaults if you'd prefer.
