### PR TITLE
Fix Windows resize corruption (poll console size into ConPTY) and stale runtime state (native liveness probe, attach-socket reaping)

### DIFF
--- a/internal/ptyhost/ptyhost_windows.go
+++ b/internal/ptyhost/ptyhost_windows.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -50,7 +51,8 @@ type Host struct {
 	clients map[net.Conn]*clientState
 	local   winsize
 	closed  bool
-	hist    history // recent output, replayed to new clients for scrollback
+	done    chan struct{} // closed by Close; stops the local-resize poller
+	hist    history       // recent output, replayed to new clients for scrollback
 }
 
 // New creates the ConPTY (sized to the current console), keeps the host
@@ -91,7 +93,9 @@ func New(sockPath string, inputOK bool) (*Host, error) {
 		inputOK:  inputOK,
 		clients:  map[net.Conn]*clientState{},
 		local:    local,
+		done:     make(chan struct{}),
 	}
+	go h.watchResize()
 
 	// The attach socket is best-effort: if AF_UNIX is unavailable (older
 	// Windows, or a Wine layer), claude still runs on the ConPTY — it
@@ -108,15 +112,59 @@ func New(sockPath string, inputOK bool) (*Host, error) {
 
 func consoleSize() winsize {
 	// Best effort: query the real console; fall back to 80x24.
-	var info windows.ConsoleScreenBufferInfo
-	if err := windows.GetConsoleScreenBufferInfo(windows.Stdout, &info); err == nil {
-		cols := uint16(info.Window.Right - info.Window.Left + 1)
-		rows := uint16(info.Window.Bottom - info.Window.Top + 1)
-		if cols > 0 && rows > 0 {
-			return winsize{rows: rows, cols: cols}
-		}
+	if sz, ok := queryConsoleSize(); ok {
+		return sz
 	}
 	return winsize{rows: 24, cols: 80}
+}
+
+// queryConsoleSize reports the real console's current window size, and
+// whether the query succeeded (it fails when stdout is redirected).
+func queryConsoleSize() (winsize, bool) {
+	var info windows.ConsoleScreenBufferInfo
+	if err := windows.GetConsoleScreenBufferInfo(windows.Stdout, &info); err != nil {
+		return winsize{}, false
+	}
+	cols := uint16(info.Window.Right - info.Window.Left + 1)
+	rows := uint16(info.Window.Bottom - info.Window.Top + 1)
+	if cols == 0 || rows == 0 {
+		return winsize{}, false
+	}
+	return winsize{rows: rows, cols: cols}, true
+}
+
+// watchResize is this host's stand-in for the Unix watchWinch: Windows
+// raises no signal when the user resizes the real console, and nothing
+// else ever refreshes h.local after New — so without a watcher a local
+// resize never reached ResizePseudoConsole, the child kept painting at
+// the stale width, and the terminal reflowed that stale-width output
+// into duplicated/overlapping frames (issue #33). Reading console input
+// records for WINDOW_BUFFER_SIZE_EVENT isn't an option — Pump streams
+// stdin raw into the ConPTY — so poll the screen-buffer info instead;
+// a query failure (redirected stdout) is not a resize and is skipped.
+func (h *Host) watchResize() {
+	t := time.NewTicker(400 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-h.done:
+			return
+		case <-t.C:
+		}
+		sz, ok := queryConsoleSize()
+		if !ok {
+			continue
+		}
+		h.mu.Lock()
+		changed := !h.closed && sz != h.local
+		if changed {
+			h.local = sz
+		}
+		h.mu.Unlock()
+		if changed {
+			h.recomputeSize()
+		}
+	}
 }
 
 // TTY / TTYDup are the Unix wiring points; on Windows the child attaches
@@ -309,6 +357,7 @@ func (h *Host) Close() {
 		return
 	}
 	h.closed = true
+	close(h.done)
 	for c := range h.clients {
 		_ = c.Close()
 	}

--- a/internal/registry/alive_test.go
+++ b/internal/registry/alive_test.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+// spawnDead runs a trivial process to completion and returns its (now
+// dead) PID, portably: `true` doesn't exist on Windows.
+func spawnDead(t *testing.T) int {
+	t.Helper()
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "exit 0")
+	} else {
+		cmd = exec.Command("true")
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Wait()
+	return pid
+}
+
+// TestProcessAliveSelf pins the probe's positive case on every platform.
+// On Windows this is the regression test for the Signal(0) probe, which
+// always errored there — reporting the calling process itself as dead
+// and making List reap live wrappers' entries.
+func TestProcessAliveSelf(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("processAlive(self) = false, want true")
+	}
+}
+
+func TestProcessAliveDead(t *testing.T) {
+	if pid := spawnDead(t); processAlive(pid) {
+		t.Errorf("processAlive(%d) = true for an exited process, want false", pid)
+	}
+}

--- a/internal/registry/alive_unix.go
+++ b/internal/registry/alive_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package registry
+
+import (
+	"os"
+	"syscall"
+)
+
+// processAlive probes pid with the null signal. EPERM means the process
+// exists but belongs to another user — alive, not reapable.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	return err == syscall.EPERM
+}

--- a/internal/registry/alive_windows.go
+++ b/internal/registry/alive_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package registry
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// stillActive is GetExitCodeProcess's "hasn't exited" sentinel
+// (STILL_ACTIVE, 259) — x/sys/windows doesn't export it.
+const stillActive = 259
+
+// processAlive reports whether pid is a running process. The Unix
+// probe — Signal(0) — always errors with "not supported by windows"
+// here, which List misread as "dead" and reaped every entry, live ones
+// included. Open the process and ask for its exit code instead:
+// STILL_ACTIVE means running. An access-denied open means the process
+// exists but is out of reach — alive, mirroring the Unix EPERM case —
+// and an unqueryable handle is kept too: reaping must only ever act on
+// certainty.
+func processAlive(pid int) bool {
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return errors.Is(err, windows.ERROR_ACCESS_DENIED)
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return true
+	}
+	return code == stillActive
+}

--- a/internal/registry/reap_test.go
+++ b/internal/registry/reap_test.go
@@ -1,0 +1,43 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/inulute/cux/internal/paths"
+)
+
+// TestReapStaleAttachSockets: only sockets belonging to dead wrappers go;
+// the live wrapper's socket and anything that isn't a PID-named socket
+// stay untouched.
+func TestReapStaleAttachSockets(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := os.MkdirAll(paths.AttachDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	touch := func(name string) string {
+		p := filepath.Join(paths.AttachDir(), name)
+		if err := os.WriteFile(p, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	deadSock := touch(strconv.Itoa(spawnDead(t)) + ".sock")
+	liveSock := touch(strconv.Itoa(os.Getpid()) + ".sock")
+	junkSock := touch("not-a-pid.sock")
+	other := touch("readme.txt")
+
+	ReapStaleAttachSockets()
+
+	if _, err := os.Stat(deadSock); !os.IsNotExist(err) {
+		t.Error("dead wrapper's socket should have been reaped")
+	}
+	for _, p := range []string{liveSock, junkSock, other} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("%s should have been kept: %v", filepath.Base(p), err)
+		}
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"syscall"
+	"strings"
 	"time"
 
 	"github.com/inulute/cux/internal/atomicfile"
@@ -109,17 +109,30 @@ func List() []Entry {
 	return out
 }
 
-// processAlive probes pid with the null signal. On platforms where the
-// probe is unsupported it reports true, so entries are kept rather
-// than wrongly reaped.
-func processAlive(pid int) bool {
-	p, err := os.FindProcess(pid)
+// ReapStaleAttachSockets removes attach sockets left behind by wrappers
+// that crashed or were killed: the listener died with its process, so a
+// socket whose PID (its filename) is gone can never accept again — but
+// while the file exists, attach surfaces (`cux attach`, cuxdeck bridges)
+// keep probing a dead endpoint. Called at wrapper startup so the attach
+// directory is self-healing, the same way List is for session entries.
+// A wrapper's live socket is untouched: its PID probe says alive.
+func ReapStaleAttachSockets() {
+	entries, err := os.ReadDir(paths.AttachDir())
 	if err != nil {
-		return false
+		return
 	}
-	err = p.Signal(syscall.Signal(0))
-	if err == nil {
-		return true
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || filepath.Ext(name) != ".sock" {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSuffix(name, ".sock"))
+		if err != nil || pid <= 0 {
+			continue
+		}
+		if pid == os.Getpid() || processAlive(pid) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(paths.AttachDir(), name))
 	}
-	return err == syscall.EPERM
 }

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -123,6 +123,9 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 	var host *ptyhost.Host
 	if cfg.Attach && term.IsTerminal(int(os.Stdin.Fd())) {
 		_ = os.MkdirAll(paths.AttachDir(), 0o700)
+		// Crashed wrappers leave their sockets behind; sweep the dead
+		// ones so attach surfaces never probe endpoints that can't answer.
+		registry.ReapStaleAttachSockets()
 		if h, err := ptyhost.New(paths.AttachSock(pid), cfg.AttachInput); err == nil {
 			host = h
 			defer host.Close()


### PR DESCRIPTION
Fixes the two mechanisms behind #33.

## 1. Resize corruption: no local-resize watcher on the Windows host

The report's suspicion was right, and the gap is exact: the ConPTY host measures the real console **once**, in `New()`. The Unix host has `watchWinch()` (SIGWINCH → refresh `h.local` → `recomputeSize()`), but Windows raises no signal on resize and nothing else ever refreshed `h.local` — so a local terminal resize **never called `ResizePseudoConsole`**. Claude Code kept painting at the stale width, Windows Terminal reflowed that stale-width stream, and you get exactly the duplicated/overlapping frames described (with `Ctrl+L` fixing precisely one frame). It also explains why 0.2.10 was clean: it had no PTY layer at all — claude inherited the wrapper's stdio and sat directly on the real console, so resize reached it natively.

The fix mirrors `watchWinch` with the standard ConPTY-proxy approach: a poller on `GetConsoleScreenBufferInfo` (console input records aren't an option — `Pump` streams stdin raw into the ConPTY), running the usual tmux-rule negotiation only when the size actually changed. Query failures (redirected stdout) are skipped rather than treated as a resize, and the poller stops with `Close()`.

## 2. Stale runtime state: liveness probe broken on Windows + no attach-socket reaper

The self-healing the follow-up comment asks for actually already exists — `registry.List()` reaps dead-PID entries — but it was broken on the exact platform of this report: `processAlive` probes with `Signal(0)`, which on Windows always errors with `"not supported by windows"`. That's not `EPERM`, so every **live** process read as dead, and the reaper was useless there. Now probed natively: `OpenProcess` + `GetExitCodeProcess == STILL_ACTIVE`, with access-denied treated as alive to mirror the Unix `EPERM` case.

Attach sockets additionally had no reaper anywhere — a crashed wrapper's socket stayed forever, which is how 26 stale entries accumulated. Wrapper startup now sweeps sockets whose PID is dead (the listener died with its process, so they can never accept again), the same contract `List` provides for session entries.

One honest note on the hook hang: `cux hook prompt-submit` never touches `sessions/` or `attach/` in current code, so the "iterates the registry and dials each dead socket" hypothesis doesn't match the code I can see — the 60s hangs may have come from the mixed-version state (or `monitor.RefreshAll()`'s network refresh on the auto-switch path). The stale-state cleanup here is worth having regardless, but if the hang reproduces on a clean 0.3.x install, fresh logs would help pin the remaining mechanism down.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` pass on macOS
- [x] `GOOS=windows go build ./...` and `GOOS=windows go test -c` (ptyhost, registry, wrapper) compile cleanly; `GOOS=windows go vet` reports only the pre-existing `unsafe.Pointer` note in `StartAttached`, present on `main`
- [x] New cross-platform tests: `processAlive(self)`/`processAlive(dead)` (the self case is the Windows regression test) and `ReapStaleAttachSockets` (dead socket reaped; live socket, non-PID socket, and non-socket files kept)
- [ ] Manual check on Windows 11 + Windows Terminal: resize during a wrapped session no longer corrupts (I don't have a Windows box in this environment — @Orbita-Media offered to test a patched build, and this branch cross-compiles with `GOOS=windows go build ./cmd/cux`)
