### PR TITLE
wait-for-reset: sleep the full known duration and never strand the session (was: 4 short waits, then self-exit)

### DIFF
--- a/internal/hooks/apifailure_test.go
+++ b/internal/hooks/apifailure_test.go
@@ -27,6 +27,27 @@ func TestClassifyFailure(t *testing.T) {
 			want: signals.RateLimited,
 		},
 		{
+			// The usage-cap wording without the word "usage": treating
+			// this as a generic API failure sent the wrapper into an
+			// endless fixed-backoff retry loop on an account with no
+			// capacity, instead of swapping / sleeping until the reset.
+			name: "hit-your-limit wording is a rate limit, not a retry",
+			in: rateLimitHookInput{
+				HookEventName:        "StopFailure",
+				Error:                rawStr("error"),
+				LastAssistantMessage: rawStr("You've hit your limit · resets 7pm"),
+			},
+			want: signals.RateLimited,
+		},
+		{
+			name: "weekly limit reached wording is a rate limit",
+			in: rateLimitHookInput{
+				HookEventName: "StopFailure",
+				Error:         rawStr("Weekly limit reached — your limit will reset on Thursday"),
+			},
+			want: signals.RateLimited,
+		},
+		{
 			name: "API error in the error field triggers a retry",
 			in: rateLimitHookInput{
 				HookEventName: "StopFailure",

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -988,6 +988,15 @@ func classifyFailure(in rateLimitHookInput) (signals.Name, string) {
 		strings.Contains(lower, "session limit") ||
 		strings.Contains(lower, "hit your session limit") ||
 		strings.Contains(lower, "usage limit") ||
+		// Claude Code's user-facing wording for the usage caps drops the
+		// word "usage" in several builds ("You've hit your limit —
+		// resets 7pm", "Weekly limit reached"). Missing these turned an
+		// exhausted account into an endless fixed-backoff retry loop in
+		// the wrapper instead of a swap / sleep-until-reset.
+		strings.Contains(lower, "hit your limit") ||
+		strings.Contains(lower, "reached your limit") ||
+		strings.Contains(lower, "limit reached") ||
+		strings.Contains(lower, "limit will reset") ||
 		strings.Contains(lower, "overloaded_error") ||
 		strings.Contains(lower, "too many requests") ||
 		strings.Contains(lower, "429")

--- a/internal/wrapper/waitforreset_test.go
+++ b/internal/wrapper/waitforreset_test.go
@@ -1,0 +1,54 @@
+package wrapper
+
+import (
+	"testing"
+
+	"github.com/inulute/cux/internal/store"
+	"github.com/inulute/cux/internal/usage"
+)
+
+// TestAllTokensExpired pins waitForReset's only remaining hard exit:
+// waiting is declared futile ONLY when every pooled account's
+// credentials are known-expired. Anything ambiguous (missing usage
+// data, one healthy token) must keep the wait alive — the old
+// fixed-attempt version turned a normal all-exhausted night into four
+// short waits and a dead session.
+func TestAllTokensExpired(t *testing.T) {
+	accounts := map[int]store.Account{
+		1: {Slot: 1, Email: "a@x.test"},
+		2: {Slot: 2, Email: "b@x.test"},
+	}
+
+	t.Run("all expired → futile", func(t *testing.T) {
+		cache := usage.Cache{
+			"a@x.test": {TokenExpired: true},
+			"b@x.test": {TokenExpired: true},
+		}
+		if !allTokensExpired(accounts, cache) {
+			t.Error("want true when every account needs a login")
+		}
+	})
+
+	t.Run("one live token → keep waiting", func(t *testing.T) {
+		cache := usage.Cache{
+			"a@x.test": {TokenExpired: true},
+			"b@x.test": {TokenExpired: false},
+		}
+		if allTokensExpired(accounts, cache) {
+			t.Error("a single healthy token means the wait can succeed")
+		}
+	})
+
+	t.Run("missing usage data counts as healable", func(t *testing.T) {
+		cache := usage.Cache{"a@x.test": {TokenExpired: true}}
+		if allTokensExpired(accounts, cache) {
+			t.Error("an account the next refresh may fill in must not end the wait")
+		}
+	})
+
+	t.Run("empty pool → nothing to wait for", func(t *testing.T) {
+		if !allTokensExpired(map[int]store.Account{}, usage.Cache{}) {
+			t.Error("want true for an empty pool")
+		}
+	})
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -201,6 +201,25 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			if hadTurns {
 				apiRetries = 0
 			}
+			// A hard usage limit can reach us dressed as a generic API
+			// failure: the classifier only sees error text, and Claude
+			// Code's wording for the cap shifts between builds. Backoff is
+			// the wrong tool for exhaustion — the account has no capacity
+			// to retry into, and when the whole pool is out the reset
+			// clocks are all known. Check fresh usage and, if the live
+			// account is actually out, promote to the rate-limit path
+			// (swap if anything is usable, else wait-for-reset sleeps
+			// until the earliest known reset) instead of fixed-interval
+			// relaunches that spin against a closed window until a human
+			// returns.
+			_, _ = monitor.RefreshAll()
+			if isActiveHardLimited() {
+				lk, _ := switcher.CurrentLiveCacheKey()
+				fmt.Fprintf(w, "cux: that API failure is a usage limit on the live account — switching instead of retrying\n")
+				p = &pending{trigger: history.TriggerRateLimit, reason: p.reason, fromUsage: snapshotActiveUsage(), fromKey: lk}
+			}
+		}
+		if p != nil && p.retryOnly {
 			delay := fibonacciDelay(apiRetries)
 			apiRetries++
 			fmt.Fprintf(w, "cux: API failure after claude's own retries (%s) — auto-continuing in %s (attempt %d)…\n",

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -829,17 +829,22 @@ func isActiveHardLimited() bool {
 	return ok && isHardLimitUsage(u)
 }
 
-// waitForReset blocks until the earliest moment a managed account
-// becomes usable again, refreshes usage, and retries target resolution.
-// Reached only when every account is exhausted — the alternative was
-// giving up and stranding an unattended session until a human returns.
-// A few attempts guard against clock skew between the local machine
-// and the API's reset stamps; each retry waits for the next reset, so
-// even the fallback path never spins.
+// waitForReset blocks until a managed account is usable again, then
+// returns it. Reached only when every account is exhausted — and an
+// unattended session must ride that out, not die. The reset clocks are
+// known, so the first sleep already spans the whole outage (plus slack
+// for clock skew and server-side rounding); rounds where the cache is
+// stale or no reset clock is published yet re-check on the poll cadence
+// instead of giving up. It used to abort after a fixed number of
+// attempts, which in practice meant a handful of short waits followed
+// by "accounts still exhausted" and a dead session — exactly the
+// stranding this function exists to prevent. The only unrecoverable
+// exit left is when every pooled account needs a fresh login: no amount
+// of waiting fixes revoked credentials.
 const (
-	waitForResetAttempts = 4
 	// waitPollInterval is how often a sleeping waitForReset re-reads
-	// the shared cache for capacity another session may have created.
+	// the shared cache for capacity another session may have created,
+	// and the re-check cadence while no reset clock is known.
 	waitPollInterval = time.Minute
 	// resetSlack pads each sleep so we wake after the API-side window
 	// has actually rolled over, not in the same second it should.
@@ -850,7 +855,7 @@ const (
 )
 
 func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (string, error) {
-	for attempt := 0; attempt < waitForResetAttempts; attempt++ {
+	for {
 		// Check first, then time. Refresh from the API so the verdict and
 		// the reset clock use current data — never a stale cache whose
 		// resets_at may already be in the past (which used to yield a
@@ -867,7 +872,19 @@ func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (str
 		cache, _ := usage.LoadCache()
 		readyAt, email, ok := nextAvailability(state.PoolForCwd(), cache, cfg.Thresholds, time.Now())
 		if !ok {
-			return "", errors.New("all accounts exhausted and no reset time is known")
+			if allTokensExpired(state.PoolForCwd(), cache) {
+				return "", errors.New("every account needs a fresh login (`cux add`) — waiting cannot help")
+			}
+			// No usable reset clock yet — the cache is catching up after
+			// a roll-over, or the API hasn't published one. Time heals
+			// this; re-check shortly instead of abandoning the session.
+			fmt.Fprintf(w, "\r\033[Kcux: all accounts exhausted; no reset clock known yet — re-checking in %s…", shortDuration(waitPollInterval))
+			registry.UpdateSelf(func(e *registry.Entry) {
+				e.State = registry.StateWaitingReset
+				e.Detail = "waiting for a reset clock"
+			})
+			time.Sleep(waitPollInterval)
+			continue
 		}
 		// resetSlack pads past the reset; add another minute of margin so
 		// we resume a bit after the window rolls over rather than the
@@ -917,8 +934,28 @@ func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (str
 		}
 		fmt.Fprintln(w) // close the in-place countdown line before relaunch output
 		// Deadline reached — loop back to the check-first refresh above.
+		// If the account still reads exhausted (server-side rounding,
+		// cache lag), the next round computes a fresh deadline from
+		// fresh data rather than giving up.
 	}
-	return "", errors.New("accounts still exhausted after waiting for resets")
+}
+
+// allTokensExpired reports whether waiting is provably futile: every
+// pooled account's credentials are known-expired, so no reset clock
+// will ever tick capacity back. Accounts with no usage data yet count
+// as healable — the next refresh may fill them in. An empty pool has
+// nothing to wait for.
+func allTokensExpired(accounts map[int]store.Account, cache usage.Cache) bool {
+	if len(accounts) == 0 {
+		return true
+	}
+	for _, a := range accounts {
+		u, found := cachedUsage(cache, a.CacheKey(), a.Email)
+		if !found || !u.TokenExpired {
+			return false
+		}
+	}
+	return true
 }
 
 // liveAccountWithCapacity returns the managed account currently


### PR DESCRIPTION
## Symptom

With every account exhausted and `wait_for_reset` on, the wrapper waits ~a minute, waits ~a minute, waits ~a minute, waits ~a minute — then prints "accounts still exhausted after waiting for resets" and **exits**, stranding the session. All while the reset clock of every account is sitting right there in the usage cache: it should have slept, say, 15 minutes on the very first try and resumed automatically when the window rolled over.

## Root causes (three, compounding)

1. **`waitForReset` gives up after 4 attempts.** When the cached `resets_at` is stale (already in the past while utilization still reads ≥100 — routine right around a roll-over, or after laptop sleep), the computed deadline collapses to the short floor (`resetSlack+resetBuffer`), so an "attempt" burns in ~2 minutes. Four floor-length attempts ≈ the reported behavior, then the hard error — and `Run` treats that error as fatal and returns. The function built to keep unattended sessions alive is the thing killing them.

2. **Claude Code's cap wording can defeat the classifier.** `classifyFailure` matched "usage limit", "session limit", 429 &c. — but several builds word the cap as "You've hit your limit · resets 7pm" or "Weekly limit reached". Those fell through to `TurnFailed`, so exhaustion entered the *API-failure* fibonacci loop (10s…2m, forever) instead of the rate-limit path — short fixed waits despite fully-known reset clocks.

3. **No usage cross-check on the retry path.** Even with a perfect classifier, an exhausted account reaching the retry-only path has no capacity to retry into; backoff is the wrong tool whenever fresh usage says the live seat is at a hard cap.

## Fixes (one commit each)

- **`wrapper: wait-for-reset never gives up`** — drop the attempt cap. The first sleep already spans the whole outage (earliest reset + slack); a round that wakes to still-exhausted data recomputes a fresh deadline from a fresh refresh; a round with no published reset clock re-checks on the poll cadence until the data heals. The one hard exit left is provable futility: **every** pooled account's token expired (no amount of waiting fixes revoked credentials — `allTokensExpired`, covered by tests). Same unbounded-by-design rationale as the fibonacci retry loop: a human can always Ctrl+C.
- **`hooks: recognize unworded usage-cap messages`** — add "hit your limit", "reached your limit", "limit reached", "limit will reset" to the rate-limit patterns (table-driven tests added).
- **`wrapper: divert exhausted-account API failures`** — belt to those braces: on a retry-only pending, refresh usage first and, if the live account is hard-limited, promote to the rate-limit path (swap if anything is usable, else wait-for-reset) instead of fibonacci relaunches against a closed window.

## Test plan

- [x] `go build ./...`, `go vet ./internal/...`, `gofmt` clean
- [x] `go test -race ./...` passes; new tests: `TestAllTokensExpired` (the only remaining hard exit), classifier cases for the new cap wordings
- [x] `GOOS=windows go build ./...` clean
- [ ] Overnight soak with a genuinely exhausted pool (the countdown → auto-resume path needs real reset clocks to fully exercise)
