### PR TITLE
wrapper: never wait-for-reset while the live seat has real capacity (#37)

### DIFF
--- a/internal/wrapper/availability_test.go
+++ b/internal/wrapper/availability_test.go
@@ -57,14 +57,44 @@ func TestNextAvailability(t *testing.T) {
 		}
 	})
 
-	t.Run("account under threshold is ready now", func(t *testing.T) {
+	t.Run("under-threshold account is never named as earliest reset", func(t *testing.T) {
+		// a is exhausted (reset in2h); b has plenty of room. b must not be
+		// reported as "ready now" — it has capacity, so there is nothing to
+		// wait for, and naming it produces the bogus sub-slack countdown of
+		// issue #37. The genuinely-capped account's reset is what a wait
+		// should target.
 		cache := usage.Cache{
 			"a@x.test": {FiveHour: win(100, &in2h)},
 			"b@x.test": {FiveHour: win(30, &in1h)},
 		}
 		at, email, ok := nextAvailability(accounts, cache, th, now)
-		if !ok || email != "b@x.test" || !at.Equal(now) {
-			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, now, "b@x.test")
+		if !ok || email != "a@x.test" || !at.Equal(in2h) {
+			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, in2h, "a@x.test")
+		}
+	})
+
+	t.Run("all accounts under threshold → nothing to wait for", func(t *testing.T) {
+		cache := usage.Cache{
+			"a@x.test": {FiveHour: win(20, &in1h), SevenDay: win(7, &in3d)},
+			"b@x.test": {FiveHour: win(30, &in2h), SevenDay: win(9, &in3d)},
+		}
+		if at, email, ok := nextAvailability(accounts, cache, th, now); ok {
+			t.Errorf("got (%v, %q, true), want ok=false — no account is over threshold", at, email)
+		}
+	})
+
+	t.Run("a capped window whose reset is already past is skipped", func(t *testing.T) {
+		past := now.Add(-5 * time.Minute)
+		cache := usage.Cache{
+			// a's 5h window is over the cap but its stamped reset already
+			// elapsed (cache lag after a roll-over) — treat as unknown and
+			// re-poll rather than returning a sub-slack now-ish deadline.
+			"a@x.test": {FiveHour: win(100, &past)},
+			"b@x.test": {FiveHour: win(100, &in2h)},
+		}
+		at, email, ok := nextAvailability(accounts, cache, th, now)
+		if !ok || email != "b@x.test" || !at.Equal(in2h) {
+			t.Errorf("got (%v, %q, %v), want (%v, %q, true)", at, email, ok, in2h, "b@x.test")
 		}
 	})
 

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -180,6 +180,16 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 	// upper bound by design: an unattended session should outlast even
 	// a multi-hour outage, and a human can always Ctrl+C.
 	var apiRetries int
+	// inPlaceRetries scales a separate fibonacci backoff for the case
+	// where a rate limit fires but no other seat has capacity and the
+	// live seat still does (a transient usage-endpoint 429, or a
+	// session/burst sub-cap that never moves the 5h/7d windows). We resume
+	// on the live seat rather than stranding the session in wait-for-reset;
+	// the backoff keeps a genuinely recurring cap from tight-looping (#21).
+	// It is deliberately distinct from apiRetries, which the retry-only
+	// path zeroes every iteration — a shared counter would collapse to a
+	// constant ~10s relaunch.
+	var inPlaceRetries int
 
 	for {
 		if seat, err := switcher.CurrentLiveEmail(); err == nil {
@@ -295,6 +305,10 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 				fmt.Fprintf(w, "cux: %s already has capacity (another session may have swapped) — resuming without switching\n", acct.Email)
 				from, to = acct, acct
 				swapped = false
+				// Another session moved us onto a healthy seat — the common
+				// recovery under many concurrent sessions. Clear any in-place
+				// backoff so a later limit on this fresh seat starts from zero.
+				inPlaceRetries = 0
 			}
 		}
 
@@ -303,48 +317,79 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 			target, err := resolveTarget(p.explicitTarget, p.trigger, &cfg)
 			if err != nil && cfg.WaitForReset && p.explicitTarget == "" &&
 				(p.trigger == history.TriggerRateLimit || p.trigger == history.TriggerThreshold) {
-				target, err = waitForReset(p.trigger, &cfg, w)
+				// No other seat has capacity. Before sleeping until a
+				// reset, check whether the live seat itself still has real
+				// 5h/7d room: a rate-limit signal can fire on a healthy
+				// account — a transient 429 on the usage endpoint, or a
+				// session/burst sub-cap that never moves the tracked
+				// windows. Waiting there strands a usable session for the
+				// whole outage (often days on a 7d cap) while the live seat
+				// sits mostly free — the exact failure in issue #37. Resume
+				// in place on a backoff instead; fall through to
+				// wait-for-reset only when the live seat is out too.
+				if acct, ok := liveAccountWithCapacity(&cfg); ok {
+					if hadTurns {
+						inPlaceRetries = 0
+					}
+					delay := fibonacciDelay(inPlaceRetries)
+					inPlaceRetries++
+					fmt.Fprintf(w, "cux: %s hit a limit but no other account has capacity and it still has room — retrying in place in %s…\n",
+						acct.Email, shortDuration(delay))
+					registry.UpdateSelf(func(e *registry.Entry) {
+						e.State = registry.StateRetrying
+						e.Detail = fmt.Sprintf("retrying in place, next try in %s", shortDuration(delay))
+					})
+					time.Sleep(delay)
+					from, to, swapped, err = acct, acct, false, nil
+				} else {
+					target, err = waitForReset(p.trigger, &cfg, w)
+				}
 			}
-			if err != nil {
-				fmt.Fprintf(w, "cux: %v — staying on current account\n", err)
-				return exitCode, nil
-			}
+			if swapped {
+				// A real swap onto another seat is progress — clear any
+				// in-place backoff carried over from earlier iterations.
+				inPlaceRetries = 0
+				if err != nil {
+					fmt.Fprintf(w, "cux: %v — staying on current account\n", err)
+					return exitCode, nil
+				}
 
-			registry.UpdateSelf(func(e *registry.Entry) { e.State = registry.StateSwapping })
-			var swapErr error
-			from, to, swapErr = switcher.SwitchTo(target)
-			if swapErr != nil {
-				fmt.Fprintf(w, "cux: switch failed: %v\n", swapErr)
-				return 1, swapErr
-			}
+				registry.UpdateSelf(func(e *registry.Entry) { e.State = registry.StateSwapping })
+				var swapErr error
+				from, to, swapErr = switcher.SwitchTo(target)
+				if swapErr != nil {
+					fmt.Fprintf(w, "cux: switch failed: %v\n", swapErr)
+					return 1, swapErr
+				}
 
-			// Append swap to the history log. Best-effort — a failure
-			// here doesn't unwind the swap.
-			toUsageCache, _ := usage.LoadCache()
-			toUsage := toUsageCache[to.Email]
-			entry := history.Entry{
-				From:        from.Email,
-				To:          to.Email,
-				Trigger:     p.trigger,
-				Reason:      p.reason,
-				SessionID:   sessionID,
-				CWD:         cwd,
-				FromUsage5h: utilizationOrZero(p.fromUsage.FiveHour),
-				FromUsage7d: utilizationOrZero(p.fromUsage.SevenDay),
-				ToUsage5h:   utilizationOrZero(toUsage.FiveHour),
-				ToUsage7d:   utilizationOrZero(toUsage.SevenDay),
-			}
-			_ = history.Append(entry)
+				// Append swap to the history log. Best-effort — a failure
+				// here doesn't unwind the swap.
+				toUsageCache, _ := usage.LoadCache()
+				toUsage := toUsageCache[to.Email]
+				entry := history.Entry{
+					From:        from.Email,
+					To:          to.Email,
+					Trigger:     p.trigger,
+					Reason:      p.reason,
+					SessionID:   sessionID,
+					CWD:         cwd,
+					FromUsage5h: utilizationOrZero(p.fromUsage.FiveHour),
+					FromUsage7d: utilizationOrZero(p.fromUsage.SevenDay),
+					ToUsage5h:   utilizationOrZero(toUsage.FiveHour),
+					ToUsage7d:   utilizationOrZero(toUsage.SevenDay),
+				}
+				_ = history.Append(entry)
 
-			// Refresh both accounts' caches. The "from" entry now
-			// represents the freshest reading we have; the "to" entry
-			// will be updated again at the first Stop on the new
-			// session, but doing it here gives `cux list` correct data
-			// immediately.
-			go func(from, to string) {
-				_ = monitor.RefreshActive(from)
-				_ = monitor.RefreshActive(to)
-			}(from.Email, to.Email)
+				// Refresh both accounts' caches. The "from" entry now
+				// represents the freshest reading we have; the "to" entry
+				// will be updated again at the first Stop on the new
+				// session, but doing it here gives `cux list` correct data
+				// immediately.
+				go func(from, to string) {
+					_ = monitor.RefreshActive(from)
+					_ = monitor.RefreshActive(to)
+				}(from.Email, to.Email)
+			}
 		}
 
 		// Update the manual-switch guard. A deliberate /switch sets the
@@ -1049,6 +1094,7 @@ func nextAvailability(
 			continue
 		}
 		readyAt := now
+		blocked := false
 		unknown := false
 		for _, wc := range []struct {
 			win *usage.Window
@@ -1060,6 +1106,7 @@ func nextAvailability(
 			if wc.win == nil || wc.win.Utilization < float64(wc.cap) {
 				continue
 			}
+			blocked = true
 			if wc.win.ResetsAt == nil {
 				unknown = true
 				break
@@ -1068,7 +1115,17 @@ func nextAvailability(
 				readyAt = *wc.win.ResetsAt
 			}
 		}
-		if unknown {
+		// An account under every threshold has capacity right now — there
+		// is nothing to wait for. Naming it as the one that "reaches its
+		// reset first" hands back a now-ish deadline that resetSlack pads
+		// into a bogus ~2½-minute countdown, and since it never actually
+		// gains capacity by waiting the session relaunches into the same
+		// verdict forever (issue #37: a 7%-utilised seat named as earliest
+		// reset). Skip it. Skip too when a capped window carries no reset
+		// stamp, or its reset already lies in the past (cache lag after a
+		// roll-over) — a re-poll on the wait cadence heals both, whereas a
+		// stale past timestamp would produce the same sub-slack deadline.
+		if !blocked || unknown || !readyAt.After(now) {
 			continue
 		}
 		if bestEmail == "" || readyAt.Before(best) {


### PR DESCRIPTION
Fixes #37.

Two independent defects folded a healthy, below-threshold account into the "all accounts exhausted" verdict and stranded a live session in `wait_for_reset`.

## 1. `nextAvailability` named under-threshold accounts as the earliest reset
A seat below every threshold has capacity **now** — nothing to wait for — yet the loop left its ready-time at `now` and returned it. `resetSlack`(90s) + `resetBuffer`(60s) padded that into a ~150s deadline, which is exactly the reporter's "resuming … in 2m 3s … repeats every ~2m30s". Because waiting never gives an already-healthy seat capacity, the session relaunched into the same verdict forever, naming the one healthy account. Fixed by skipping seats over no threshold, plus skipping a capped window whose reset stamp is missing or already in the past (cache lag after a roll-over).

## 2. `wait_for_reset` was chosen over resume-in-place while the live seat still had capacity
A rate-limit signal can fire on a healthy account — a transient 429 on the usage endpoint, or a session/burst sub-cap that never moves the 5h/7d windows. With `drain` piling many sessions onto one weekly-capped seat, the swap finds no target and used to fall into `wait_for_reset`, stranding a usable session for the whole outage. Now, when no other seat has capacity **but the live seat still does**, cux resumes on it with a dedicated fibonacci backoff so a genuinely recurring cap still can't tight-loop (preserves the #21 fix).

## Note on the reported mechanism
The suspected cache-poisoning (a 429 marking the seat "exhausted") was **not** the cause: `RefreshAll` skips the cache write on any non-token-expired error, and `Fetch` returns `TokenExpired=false` on 429 — the cached `47% / 7%` survived intact. Suggestions #1/#2 in the issue describe behavior that already exists; #4 was the real bug. Coalescing usage polls (#3) is a separate, worthwhile follow-up.

## Tests
Adds `nextAvailability` coverage for the under-threshold, all-healthy, and past-reset cases (replacing a case that had encoded the buggy "ready now" expectation). `go build`, `go vet`, full `go test ./...`, and `go test -race ./internal/wrapper/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
