### PR TITLE
hooks: stop classifying tool failures and fetched pages as rate limits (#39)

### DIFF
--- a/internal/hooks/apifailure_test.go
+++ b/internal/hooks/apifailure_test.go
@@ -81,6 +81,73 @@ func TestClassifyFailure(t *testing.T) {
 			},
 			want: signals.RateLimited,
 		},
+		{
+			// Issue #39 case 1: a Claude Code concurrency refusal, not a
+			// cap. Dropped by event scoping (no strong prose, and the weak
+			// tiers require StopFailure) *and* by the denylist. The account
+			// was at 9%/36% — a swap here restarted 20 live subagents.
+			name: "concurrent subagent limit refusal is NOT a rate limit",
+			in: rateLimitHookInput{
+				HookEventName: "PostToolUseFailure",
+				Error: rawStr("Concurrent subagent limit reached. You can run 20 subagents at once. " +
+					"Do not retry. If the user wants more concurrent subagents, ask them to increase " +
+					"CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS."),
+			},
+			want: "",
+		},
+		{
+			// Issue #39 case 2: a WebFetch of a docs page that documents its
+			// own "Rate limits". The "URL: http" header marks it as fetched
+			// content, so no substring in it is trusted.
+			name: "fetched page documenting rate limits is NOT a rate limit",
+			in: rateLimitHookInput{
+				HookEventName: "PostToolUseFailure",
+				Error: rawStr("Exit code 1\nURL: https://developers.pinterest.com/apps/\r\n" +
+					"Entwicklerplattform\r\nRate limits\r\n1000/Tag\r\n"),
+			},
+			want: "",
+		},
+		{
+			// Guard ordering: foreign-content is checked before strong
+			// signals, so a fetched page that literally contains "usage
+			// limit" still does not swap — even on a StopFailure.
+			name: "foreign content beats a strong signal inside it",
+			in: rateLimitHookInput{
+				HookEventName: "StopFailure",
+				Error:         rawStr("URL: https://docs.example.com/pricing\r\nYour plan usage limit is 5000 calls."),
+			},
+			want: "",
+		},
+		{
+			// A genuine account cap surfaced through a tool call: strong
+			// prose, no foreign marker, no denylist term → still swaps.
+			name: "genuine usage-limit prose swaps even via a tool failure",
+			in: rateLimitHookInput{
+				HookEventName: "PostToolUseFailure",
+				Error:         rawStr("Claude usage limit reached. Your limit will reset at 3pm."),
+			},
+			want: signals.RateLimited,
+		},
+		{
+			// A bare 429 in a failed tool's own stderr must not swap: the
+			// weak tiers require a turn-level StopFailure.
+			name: "bare 429 from a tool failure does NOT swap",
+			in: rateLimitHookInput{
+				HookEventName: "PostToolUseFailure",
+				Error:         rawStr("HTTP 429 Too Many Requests from api.github.com"),
+			},
+			want: "",
+		},
+		{
+			// The same 429 on a StopFailure, with API context present, is
+			// a real cap and swaps.
+			name: "429 with API context on a StopFailure swaps",
+			in: rateLimitHookInput{
+				HookEventName: "StopFailure",
+				Error:         rawStr("HTTP 429 too many requests from api.anthropic.com"),
+			},
+			want: signals.RateLimited,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -924,17 +924,22 @@ func writeSessionStartUsageContext(stdout io.Writer) {
 	_, _ = stdout.Write(append(out, '\n'))
 }
 
-// RateLimit is `cux hook rate-limit`. Claude Code routes generic
-// PostToolUseFailure events through this; we filter only the "error"
-// field for rate-limit indicators before signalling.
+// RateLimit is `cux hook rate-limit`. Claude Code routes every
+// StopFailure and PostToolUseFailure through here; classifyFailure /
+// classifyRateLimit decide whether the payload is a genuine account-level
+// rate/usage cap (→ swap) or a retryable API failure (→ backoff), and drop
+// everything else. Because a swap restarts the wrapped process, that
+// decision is deliberately conservative — see classifyRateLimit for the
+// ordered guards: foreign-content and denylist rejects first, then strong
+// natural-language cap phrasings on any event, and technical tokens
+// (429, rate_limit_error) only on a turn-level StopFailure. In particular
+// a single PostToolUseFailure accepts strong prose only, so a failed
+// tool's stderr or a fetched web page can't rotate the seat (#39).
 //
-// We intentionally search only the error field — not tool_input or
-// the full payload — to avoid false positives when Claude generates or
-// executes code that happens to contain "rate_limit" as a variable
-// name or string literal.
-//
-// The "error" field can be a JSON string or a JSON object depending on
-// the Claude Code version; we extract its text from either shape.
+// Only the structured "error"/"error_details" fields and
+// last_assistant_message are searched — never tool_input or the full
+// payload — and each field may be a JSON string or object, which
+// extractErrorText normalises.
 func RateLimit(stdin io.Reader) error {
 	if !isWrapped() {
 		return nil
@@ -983,33 +988,8 @@ func classifyFailure(in rateLimitHookInput) (signals.Name, string) {
 	}
 
 	lower := strings.ToLower(combined)
-	isRateLimit := strings.Contains(lower, "rate_limit") ||
-		strings.Contains(lower, "rate limit") ||
-		strings.Contains(lower, "session limit") ||
-		strings.Contains(lower, "hit your session limit") ||
-		strings.Contains(lower, "usage limit") ||
-		// Claude Code's user-facing wording for the usage caps drops the
-		// word "usage" in several builds ("You've hit your limit —
-		// resets 7pm", "Weekly limit reached"). Missing these turned an
-		// exhausted account into an endless fixed-backoff retry loop in
-		// the wrapper instead of a swap / sleep-until-reset.
-		strings.Contains(lower, "hit your limit") ||
-		strings.Contains(lower, "reached your limit") ||
-		strings.Contains(lower, "limit reached") ||
-		strings.Contains(lower, "limit will reset") ||
-		strings.Contains(lower, "overloaded_error") ||
-		strings.Contains(lower, "too many requests") ||
-		strings.Contains(lower, "429")
-
-	if isRateLimit {
-		message := assistantText
-		if message == "" {
-			message = detailText
-		}
-		if message == "" {
-			message = errText
-		}
-		return signals.RateLimited, message
+	if name, message := classifyRateLimit(in, lower, errText, detailText, assistantText); name != "" {
+		return name, message
 	}
 
 	// Non-rate-limit API failure. Two extra guards beyond the rate-limit
@@ -1037,6 +1017,106 @@ func classifyFailure(in rateLimitHookInput) (signals.Name, string) {
 // apiStatusCode matches 5xx status codes as standalone tokens so a
 // number embedded in unrelated text ("215000 tokens") never counts.
 var apiStatusCode = regexp.MustCompile(`\b(500|502|503|504|529)\b`)
+
+// classifyRateLimit decides whether a failure payload is a genuine
+// account-level rate/usage limit that warrants a seat swap. A swap
+// restarts the wrapped Claude Code process (killing in-flight work), so
+// a false positive is destructive — this classifier is deliberately
+// conservative. Issue #39: v0.3.3 broadened the match to a bare
+// "limit reached", which then fired on "concurrent subagent limit
+// reached" (a Claude Code refusal, not a cap) and on fetched web pages
+// that merely document their own "rate limits". Both restarted healthy
+// accounts and one killed 20 running subagents.
+//
+// lower is the lower-cased join of all populated fields; the raw field
+// texts are passed through so the swap-history message stays readable.
+func classifyRateLimit(in rateLimitHookInput, lower, errText, detailText, assistantText string) (signals.Name, string) {
+	// Guard 1 — foreign content, checked before any signal. A genuine
+	// Anthropic rate-limit error is a short structured message; it is
+	// never a captured web page. When the payload carries a tool's fetched
+	// document — WebFetch prefixes a "URL: <link>" header, HTML starts
+	// with a doctype/tag — nothing inside it can be trusted as an API
+	// signal, not even a strong one (a docs page may literally read
+	// "usage limits"). Structural markers only: bare links appear in
+	// legitimate cap messages (upgrade / console URLs) and must not
+	// disqualify.
+	for _, marker := range []string{"url: http", "<!doctype", "<html", "<head", "<body"} {
+		if strings.Contains(lower, marker) {
+			return "", ""
+		}
+	}
+
+	// Guard 2 — denylist. These name a *different* limit than the account
+	// cap, or explicitly declare the condition non-retryable. They must
+	// never swap even though the word "limit" appears.
+	for _, deny := range []string{
+		"do not retry",
+		"concurrent subagent", "concurrent_subagents", "max_concurrent_subagents",
+		"context window", "context length", "maximum context",
+		"token limit", "output limit", "output token", "max tokens",
+		"character limit", "file size", "recursion limit",
+	} {
+		if strings.Contains(lower, deny) {
+			return "", ""
+		}
+	}
+
+	message := assistantText
+	if message == "" {
+		message = detailText
+	}
+	if message == "" {
+		message = errText
+	}
+
+	// Strong signals — natural-language account/usage-cap phrasings that
+	// do not occur incidentally in tool output or code. Trusted on any
+	// event: a real cap can surface through a tool call as well as a turn.
+	for _, s := range []string{
+		"usage limit",
+		"session limit",
+		"hit your limit", "reached your limit",
+		"weekly limit", "limit will reset",
+		"upgrade to increase your usage",
+	} {
+		if strings.Contains(lower, s) {
+			return signals.RateLimited, message
+		}
+	}
+
+	// The remaining signals are technical tokens that can legitimately
+	// appear in a failed tool's own output (another service's 429, a
+	// linter flagging a `rate_limit` identifier). Restrict them to a
+	// turn-level StopFailure — the whole turn dying after Claude Code
+	// exhausted its retries — never a single PostToolUseFailure.
+	if in.HookEventName != "StopFailure" {
+		return "", ""
+	}
+	// Anthropic API error types are unambiguous on a StopFailure.
+	for _, s := range []string{"rate_limit_error", "rate_limit", "overloaded_error"} {
+		if strings.Contains(lower, s) {
+			return signals.RateLimited, message
+		}
+	}
+	// Generic phrasings still need an API/Anthropic context token nearby,
+	// so a turn that merely discusses "rate limit" or fails for an
+	// unrelated reason does not rotate the seat.
+	generic := false
+	for _, s := range []string{"429", "too many requests", "quota exceeded", "rate limit"} {
+		if strings.Contains(lower, s) {
+			generic = true
+			break
+		}
+	}
+	if generic {
+		for _, ctx := range []string{"api", "anthropic", "claude", "http", "status", "response", "overloaded", "retry-after", "retry after"} {
+			if strings.Contains(lower, ctx) {
+				return signals.RateLimited, message
+			}
+		}
+	}
+	return "", ""
+}
 
 // isAPIFailure reports whether an error string from StopFailure looks
 // like a transport- or server-side API failure worth retrying, as


### PR DESCRIPTION
Fixes #39.

A rate-limit verdict makes cux swap accounts, which **restarts the wrapped Claude Code process** — so a false positive is destructive. Two payloads on fully healthy accounts triggered swaps:

- **Case 1** — a `Concurrent subagent limit reached … Do not retry` refusal (not a cap; the account was at 9% / 36%). The restart killed ~20 running research subagents.
- **Case 2** — a `WebFetch` of a docs page that documents its own *"Rate limits"*, matched as fetched page content.

## Root cause
The classifier used a flat `strings.Contains` over all fields for **both** `StopFailure` and `PostToolUseFailure`, with none of the event/field scoping the API-failure branch beside it already has. Case 1 matched the bare `"limit reached"` substring I added in v0.3.3 (#37); Case 2 matched `"rate limit"` in fetched content.

## Fix — a conservative, ordered classifier (`classifyRateLimit`)
1. **Foreign-content guard, first.** A payload carrying a fetched document (`URL: http` header, `<!doctype`/`<html`) is never an API signal — not even a strong one — so a docs page reading "usage limits" can't swap.
2. **Denylist.** `do not retry`, `concurrent subagent`, context-window / token / output / file-size limits — a *different* limit than the account cap, or explicitly non-retryable.
3. **Strong prose (any event).** `usage limit`, `session limit`, `hit your limit`, `weekly limit`, `limit will reset`, … — natural-language caps that don't occur incidentally, so a genuine cap surfaced through a tool call still swaps.
4. **Technical tokens (`rate_limit_error`, `429`, `too many requests`, `rate limit`) only on a turn-level `StopFailure`**, and the generic tier also needs an API/Anthropic context token nearby. A single failed tool's stderr (another service's 429) never rotates the seat.

This is the structural answer to the reporter's item 4 (narrowing the `.*` matcher): Claude Code matches tool *names* there, so no subset means "account limits" — event scoping in the classifier is the right lever, not the matcher.

## Tests
Every #33/#37 wording is preserved (existing cases unchanged and passing). Adds coverage for both real-world #39 payloads, the guard-ordering invariant (foreign content beats a strong signal inside it), a genuine cap via a tool failure, and the `429`-needs-StopFailure boundary. `go build`, `go vet`, and full `go test ./...` pass.

## Deliberately out of scope (separate follow-ups)
- Reporter's suggestion 3 (swap cooldown): fixing classification removes Case 1's 6s cascade, and a blanket cooldown could suppress a *real* second cap in a 3-account pool.
- Observations (a) dead registry entries, (b) `balanced` not redistributing off an exhausted seat, (c) usage-endpoint 429s under many terminals — three distinct concerns, each to be filed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
