### PR TITLE
registry+monitor: prune dead session entries; coalesce startup usage polls (#39)

### DIFF
--- a/internal/monitor/freshness_test.go
+++ b/internal/monitor/freshness_test.go
@@ -1,0 +1,33 @@
+package monitor
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFreshEnough(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	maxAge := 20 * time.Second
+
+	cases := []struct {
+		name     string
+		polledAt time.Time
+		maxAge   time.Duration
+		want     bool
+	}{
+		{"polled just now is fresh", now.Add(-2 * time.Second), maxAge, true},
+		{"polled inside the window is fresh", now.Add(-19 * time.Second), maxAge, true},
+		{"polled at the window boundary is stale", now.Add(-maxAge), maxAge, false},
+		{"polled before the window is stale", now.Add(-90 * time.Second), maxAge, false},
+		{"never polled is never fresh", time.Time{}, maxAge, false},
+		{"coalescing off (maxAge 0) never fresh", now, 0, false},
+		{"coalescing off (negative) never fresh", now, -time.Second, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := freshEnough(c.polledAt, c.maxAge, now); got != c.want {
+				t.Errorf("freshEnough(%v, %v) = %v, want %v", c.polledAt, c.maxAge, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -36,6 +36,33 @@ const lockTimeout = 10 * time.Second
 // errors so the caller can surface them without aborting the whole
 // refresh — one expired token shouldn't poison the others.
 func RefreshAll() (usage.Cache, []error) {
+	return refreshAll(0)
+}
+
+// RefreshAllCoalesced refreshes only the accounts whose cached reading is
+// missing or older than maxAge. Because the refresh holds a cross-process
+// file lock, N sessions that all poll within the same maxAge window
+// collapse to a single API sweep: the first through the lock fetches, the
+// rest find a fresh-enough cache and skip. This is the relief for the
+// usage endpoint 429ing once many cux terminals poll at once (issue #39,
+// related to #21). A maxAge <= 0 is identical to RefreshAll — every
+// account is fetched — so freshness-critical callers keep using RefreshAll.
+func RefreshAllCoalesced(maxAge time.Duration) (usage.Cache, []error) {
+	return refreshAll(maxAge)
+}
+
+// freshEnough reports whether an entry polled at polledAt is recent enough
+// that a coalesced refresh may skip re-fetching it. A zero polledAt (never
+// polled) or a non-positive maxAge (coalescing off) is never fresh enough,
+// so those always fetch.
+func freshEnough(polledAt time.Time, maxAge time.Duration, now time.Time) bool {
+	if maxAge <= 0 || polledAt.IsZero() {
+		return false
+	}
+	return now.Sub(polledAt) < maxAge
+}
+
+func refreshAll(maxAge time.Duration) (usage.Cache, []error) {
 	if err := os.MkdirAll(paths.BackupRoot(), 0o700); err != nil {
 		return nil, []error{fmt.Errorf("monitor: mkdir data dir: %w", err)}
 	}
@@ -57,7 +84,12 @@ func RefreshAll() (usage.Cache, []error) {
 		cache = usage.Cache{}
 	}
 	// Fetch all accounts in parallel — latency is dominated by the API
-	// round-trip, so N sequential calls cost N× more than needed.
+	// round-trip, so N sequential calls cost N× more than needed. Under
+	// coalescing (maxAge > 0), skip any account another session already
+	// refreshed within maxAge — the shared cache holds a current-enough
+	// reading, gated per account so a newly-added or last-errored seat is
+	// still fetched.
+	now := time.Now()
 	type result struct {
 		cacheKey string
 		entry    usage.AccountUsage
@@ -66,7 +98,12 @@ func RefreshAll() (usage.Cache, []error) {
 	}
 	ch := make(chan result, len(state.Accounts))
 	var wg sync.WaitGroup
+	fetched := 0
 	for slot, a := range state.Accounts {
+		if u, ok := cache[a.CacheKey()]; ok && freshEnough(u.PolledAt, maxAge, now) {
+			continue
+		}
+		fetched++
 		wg.Add(1)
 		go func(slot int, a store.Account) {
 			defer wg.Done()
@@ -90,8 +127,12 @@ func RefreshAll() (usage.Cache, []error) {
 		}
 		cache[r.cacheKey] = r.entry
 	}
-	if err := usage.SaveCache(cache); err != nil {
-		errs = append(errs, err)
+	// When every account was fresh enough the cache is untouched, so skip
+	// the write entirely — that no-op is the whole point of coalescing.
+	if fetched > 0 {
+		if err := usage.SaveCache(cache); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return cache, errs
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -109,6 +109,35 @@ func List() []Entry {
 	return out
 }
 
+// PruneDead removes session entries whose process is gone. List already
+// drops them as a side effect, but only when something calls it — on a
+// machine that never runs `cux sessions`, dead files pile up (issue #39:
+// 22 of 34 entries were for processes that no longer existed, some days
+// old). Called at wrapper startup, mirroring ReapStaleAttachSockets, so
+// the sessions directory is self-healing. The caller's own entry is
+// skipped: UpdateSelf may not have written it yet, and it is live anyway.
+func PruneDead() {
+	entries, err := os.ReadDir(dir())
+	if err != nil {
+		return
+	}
+	self := os.Getpid()
+	for _, de := range entries {
+		name := de.Name()
+		if de.IsDir() || filepath.Ext(name) != ".json" {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSuffix(name, ".json"))
+		if err != nil || pid <= 0 || pid == self {
+			continue
+		}
+		if processAlive(pid) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir(), name))
+	}
+}
+
 // ReapStaleAttachSockets removes attach sockets left behind by wrappers
 // that crashed or were killed: the listener died with its process, so a
 // socket whose PID (its filename) is gone can never accept again — but

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -83,6 +83,36 @@ func TestListReapsDeadProcesses(t *testing.T) {
 	}
 }
 
+func TestPruneDead(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// A real process that has already exited — its PID is dead.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	deadPID := cmd.Process.Pid
+	_ = cmd.Wait()
+
+	// Our own live entry, plus a forged dead-PID entry alongside it.
+	UpdateSelf(func(e *Entry) { e.State = StateRunning })
+	dead := file(deadPID)
+	data := []byte(`{"pid":` + itoa(deadPID) + `,"cwd":"/x","state":"running","startedAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}`)
+	if err := os.WriteFile(dead, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	PruneDead()
+
+	if _, err := os.Stat(dead); !os.IsNotExist(err) {
+		t.Error("PruneDead should have removed the dead-PID entry")
+	}
+	if _, err := os.Stat(file(os.Getpid())); err != nil {
+		t.Errorf("PruneDead removed the live self entry: %v", err)
+	}
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -115,6 +115,10 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 	// can show every concurrent session at a glance.
 	registry.UpdateSelf(func(e *registry.Entry) { e.State = registry.StateRunning })
 	defer registry.RemoveSelf()
+	// Sweep entries left by wrappers that crashed or were killed, so the
+	// sessions directory doesn't accumulate dead PIDs on a long-lived,
+	// many-terminal machine (issue #39). Best-effort; never blocks launch.
+	registry.PruneDead()
 
 	// Attachable sessions: when stdin is a real terminal, run claude on
 	// a wrapper-owned PTY and serve mirrors on a Unix socket. The PTY
@@ -169,8 +173,11 @@ func Run(claudeBin string, argv []string, w io.Writer) (int, error) {
 		// One-shot background refresh so threshold checks have something
 		// to work with on the first turn. Errors are ignored — a fresh
 		// install with no usage data is fine; threshold logic falls back
-		// to "no decision" rather than guessing.
-		go func() { _, _ = monitor.RefreshAll() }()
+		// to "no decision" rather than guessing. Coalesced: when many
+		// terminals start together this is the burst that 429s the usage
+		// endpoint (#39), and a reading a sibling took seconds ago is
+		// exactly as good for a first-turn warm-up.
+		go func() { _, _ = monitor.RefreshAllCoalesced(refreshCoalesceWindow) }()
 	}
 
 	var resumeRetryPending bool
@@ -897,6 +904,11 @@ const (
 	// resetBuffer is extra margin on top of resetSlack so a resume lands
 	// a bit after the reset rather than exactly on it.
 	resetBuffer = time.Minute
+	// refreshCoalesceWindow is how recent a sibling's usage poll must be
+	// for a startup warm-up to reuse it instead of hitting the API. Kept
+	// well under waitPollInterval so no freshness-sensitive caller could
+	// ever be starved of a current reading by coalescing.
+	refreshCoalesceWindow = 20 * time.Second
 )
 
 func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (string, error) {


### PR DESCRIPTION
Follow-ups to #39 — the two secondary observations that are clear, self-contained fixes. Observation (b) is intentionally left for a separate, data-gathering issue (see below).

## (a) Prune dead session-registry entries
`registry.List()` already drops entries whose PID is gone — but only when something *calls* it, which an idle terminal never does. On a long-lived many-terminal machine the files pile up (the reporter had **22 dead of 34**, some days old). Adds `registry.PruneDead()`, mirroring the existing `ReapStaleAttachSockets()`, called once at wrapper startup so the sessions directory self-heals. Skips its own PID.

## (c) Coalesce the startup usage poll
`RefreshAll` already holds a cross-process file lock, so concurrent polls serialize — but each still hits the API, and beyond ~6 terminals the usage endpoint 429s. Adds `RefreshAllCoalesced(maxAge)`: under the same lock it skips any account whose cached reading is younger than `maxAge`, so N sessions polling within the window collapse to **one** API sweep (first through the lock fetches; the rest reuse the fresh cache and skip the write). The gate is **per account**, so a newly-added or last-errored seat is still fetched.

Only the **startup warm-up** refresh uses the coalesced variant (20s window, well under `waitPollInterval`). Every freshness-critical caller — `waitForReset`, the prompt-submit threshold check, the API-failure exhaustion probe, and the swap path reworked in #37 — keeps calling `RefreshAll` and is byte-for-byte unchanged. This pairs with the #37 fix (a 429 no longer poisons the cache), so the "misleading exhausted readings" class the reporter mentioned is now covered from both sides.

## (b) `balanced` not redistributing — deliberately NOT in this PR
Both trigger paths verify as working: `handleAutoSwitchPrompt` swaps an over-threshold seat on the next prompt, and the Stop handler evaluates a threshold swap at turn end. The "7 idle terminals don't migrate on their own" symptom couldn't be reproduced or localized, and it lives in the swap path just reworked for #37 — a speculative change there risks regressing that fix. It needs `swap-history.json` around the pinning and whether those terminals were mid-turn or idle at a prompt, not a blind diff.

## Tests
`PruneDead` against a forged dead-PID entry (dead removed, live self kept); `freshEnough` as a pure predicate across the window boundary, never-polled, and coalescing-off cases. `go build`, `go vet`, full `go test ./...`, and `-race` on wrapper+monitor all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
