### PR TITLE
creds: select the macOS keychain item by content; refuse tokenless writes (#42)

### DIFF
--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -4,7 +4,7 @@
 //
 //   - "Live" credentials are wherever Claude Code itself reads from.
 //     cux must write here to actually change the active account.
-//     macOS:     Keychain, generic password, service "Claude Code-credentials".
+//     macOS:     Keychain generic password; see macKeychainServices.
 //     Linux/Win: File at ~/.claude/.credentials.json, mode 0600.
 //
 //   - "Backup" credentials are cux's per-account stash. On macOS/Windows
@@ -36,6 +36,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -46,10 +47,25 @@ import (
 	"github.com/inulute/cux/internal/paths"
 )
 
-// macKeychainService is the service name Claude Code itself uses on macOS.
-// We read and write under this exact string so a fresh `claude login`
-// followed by `cux add` finds the credentials in the expected place.
-const macKeychainService = "Claude Code-credentials"
+// macKeychainServices are the generic-password service names Claude Code is
+// known to keep its credentials under on macOS, in the order we try them.
+//
+// Most installs have only the first, and it holds everything. Some installs
+// — the name suggests managed/enterprise provisioning — also have the
+// second, and then the account login lives there while the classic item is
+// left holding just the `mcpOAuth` block for MCP servers (issue #42).
+// Because the classic item still *exists* in that case, selecting by name
+// silently yields credentials with no account token, so the live item is
+// chosen by content instead: see selectLiveItem.
+var macKeychainServices = []string{
+	"Claude Code-credentials",
+	"Orca Claude Code Managed Credentials",
+}
+
+// keychainExitNotFound is `security`'s exit code for "no such item".
+// Any other non-zero exit is a real failure (a denied keychain prompt, a
+// locked keychain) and must not be reported as "not logged in".
+const keychainExitNotFound = 44
 
 // backupKeyringService is cux's own namespace inside the OS keystore on
 // macOS/Windows. Distinct from claude-swap's "claude-code" so a user who
@@ -70,6 +86,17 @@ const (
 // (user never logged in, or just logged out).
 var ErrNotFound = errors.New("creds: live credentials not found")
 
+// ErrNoAccountToken is returned when credentials *were* found but carry no
+// claudeAiOauth.accessToken — an MCP-only keychain item, or a backup blob
+// captured from one.
+//
+// Kept distinct from ErrNotFound on purpose. The two conditions send a user
+// looking in completely different places: ErrNotFound means "log in",
+// ErrNoAccountToken means "the login is somewhere cux did not look, or the
+// stored copy is not a login at all". Issue #42 was hard to diagnose
+// precisely because both reported "live credentials not found".
+var ErrNoAccountToken = errors.New("creds: credentials found but they carry no account token (claudeAiOauth)")
+
 // envCredsBackend forces the plain-file storage backend on any
 // platform when set to "file". Its primary purpose is test isolation:
 // on macOS/Windows both the live and backup stores live in the OS
@@ -84,12 +111,31 @@ func fileBackendForced() bool {
 }
 
 // ReadLive returns the active credential blob Claude Code is currently
-// using. The format is an opaque JSON string — we don't parse it.
+// using. The format is otherwise opaque to us — we only check that it
+// carries an account token.
+//
+// Credentials that exist but hold no claudeAiOauth.accessToken come back as
+// ErrNoAccountToken rather than as a blob, so no caller can stash one as a
+// backup or write it back live. The macOS path already selects by content;
+// the check lives here so the file backends answer identically and the
+// sentinel is not a platform quirk.
 func ReadLive() (string, error) {
+	var (
+		blob string
+		err  error
+	)
 	if runtime.GOOS == "darwin" && !fileBackendForced() {
-		return readLiveMacOS()
+		blob, err = readLiveMacOS()
+	} else {
+		blob, err = readLiveFile()
 	}
-	return readLiveFile()
+	if err != nil {
+		return "", err
+	}
+	if err := requireAccountToken(blob); err != nil {
+		return "", err
+	}
+	return blob, nil
 }
 
 // WriteLive replaces the live credential blob Claude Code reads.
@@ -98,6 +144,9 @@ func ReadLive() (string, error) {
 func WriteLive(blob string) error {
 	if blob == "" {
 		return errors.New("creds: refusing to write empty live credentials")
+	}
+	if err := requireAccountToken(blob); err != nil {
+		return fmt.Errorf("creds: refusing to write live credentials with no account token — that would sign you out: %w", err)
 	}
 	if runtime.GOOS == "darwin" && !fileBackendForced() {
 		return writeLiveMacOS(blob)
@@ -122,6 +171,9 @@ func WriteBackup(slot int, email, blob string) error {
 	if blob == "" {
 		return errors.New("creds: refusing to write empty backup credentials")
 	}
+	if err := requireAccountToken(blob); err != nil {
+		return fmt.Errorf("creds: refusing to back up credentials with no account token — the slot would sign you out when switched to: %w", err)
+	}
 	switch {
 	case runtime.GOOS == "linux" || fileBackendForced():
 		return writeBackupFile(slot, email, blob)
@@ -133,7 +185,8 @@ func WriteBackup(slot int, email, blob string) error {
 
 // ExtractAccessToken pulls the OAuth bearer token out of a credentials
 // blob (the same JSON shape Claude Code writes to .credentials.json).
-// Returns ErrNotFound if the blob is missing the expected field.
+// Returns ErrNotFound for an empty blob and ErrNoAccountToken for a blob
+// that parses but has no claudeAiOauth.accessToken.
 //
 // The token is never logged; this helper does not surface it in any
 // error message that propagates out of the package.
@@ -150,9 +203,31 @@ func ExtractAccessToken(blob string) (string, error) {
 		return "", fmt.Errorf("creds: parse blob: %w", err)
 	}
 	if doc.ClaudeAIOAuth.AccessToken == "" {
-		return "", ErrNotFound
+		return "", ErrNoAccountToken
 	}
 	return doc.ClaudeAIOAuth.AccessToken, nil
+}
+
+// hasAccountToken reports whether blob carries a usable account token.
+func hasAccountToken(blob string) bool {
+	_, err := ExtractAccessToken(blob)
+	return err == nil
+}
+
+// requireAccountToken rejects a blob that is not a usable login. Writing
+// one over the live credentials signs the user out with no visible error,
+// and stashing one as a backup builds a slot that signs them out later when
+// it is switched to — the second-order damage in issue #42, where an MCP-only
+// keychain item was captured by `cux add` as if it were an account login.
+func requireAccountToken(blob string) error {
+	_, err := ExtractAccessToken(blob)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrNotFound) {
+		return ErrNoAccountToken
+	}
+	return err
 }
 
 // IsTokenExpired reports whether the access token in blob has already
@@ -286,31 +361,149 @@ func DeleteBackup(slot int, email string) error {
 // password, no extra metadata) and don't risk the Go library prompting
 // the user for keychain access on every read.
 
-func readLiveMacOS() (string, error) {
-	cmd := exec.Command("security", "find-generic-password",
-		"-s", macKeychainService, "-w")
-	out, err := cmd.Output()
+// macKeychainItem is one existing generic-password item we found.
+type macKeychainItem struct {
+	service string
+	blob    string
+}
+
+// errKeychainItemAbsent marks `security` exit 44 (no such item) so the
+// enumeration can skip a missing service without hiding a real failure.
+var errKeychainItemAbsent = errors.New("creds: keychain item absent")
+
+// readMacKeychainSecret returns the secret stored under one service name.
+func readMacKeychainSecret(service string) (string, error) {
+	out, err := exec.Command("security", "find-generic-password",
+		"-s", service, "-w").Output()
 	if err != nil {
-		// `security` returns exit 44 when the item isn't found.
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
-			return "", ErrNotFound
+			if ee.ExitCode() == keychainExitNotFound {
+				return "", errKeychainItemAbsent
+			}
+			return "", fmt.Errorf("creds: security find %q: exit %d: %s",
+				service, ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
 		}
-		return "", fmt.Errorf("creds: security find: %w", err)
+		return "", fmt.Errorf("creds: security find %q: %w", service, err)
 	}
 	return trimTrailingNewline(string(out)), nil
 }
 
+// findMacKeychainItems returns every known credentials item that exists, in
+// macKeychainServices order. A missing item is not an error; a keychain that
+// refuses to be read is, but only when it leaves us with nothing at all.
+func findMacKeychainItems() ([]macKeychainItem, error) {
+	var (
+		out      []macKeychainItem
+		firstErr error
+	)
+	for _, service := range macKeychainServices {
+		blob, err := readMacKeychainSecret(service)
+		if err != nil {
+			if !errors.Is(err, errKeychainItemAbsent) && firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		out = append(out, macKeychainItem{service: service, blob: blob})
+	}
+	if len(out) == 0 {
+		if firstErr != nil {
+			return nil, firstErr
+		}
+		return nil, ErrNotFound
+	}
+	return out, nil
+}
+
+// selectLiveItem picks the item cux should treat as the live credentials:
+// the first one whose blob actually carries an account token.
+//
+// When no item has one it returns the first item that exists along with
+// ErrNoAccountToken. The item is still useful to the write path — restoring
+// a backup should land in the item that is already there rather than
+// creating a new one — while the read path discards it and surfaces the
+// error, so no caller can mistake an MCP-only blob for a login.
+func selectLiveItem(items []macKeychainItem) (macKeychainItem, error) {
+	if len(items) == 0 {
+		return macKeychainItem{}, ErrNotFound
+	}
+	for _, it := range items {
+		if hasAccountToken(it.blob) {
+			return it, nil
+		}
+	}
+	return items[0], ErrNoAccountToken
+}
+
+func readLiveMacOS() (string, error) {
+	items, err := findMacKeychainItems()
+	if err != nil {
+		return "", err
+	}
+	it, err := selectLiveItem(items)
+	if err != nil {
+		return "", err
+	}
+	return it.blob, nil
+}
+
+// keychainAcctRe matches the `acct` attribute in `security`'s item dump.
+// Only the quoted form is accepted: the attribute can also print as <NULL>
+// or as a hex literal, and in both cases we would rather fall back to $USER
+// than write under a mangled account name.
+var keychainAcctRe = regexp.MustCompile(`(?m)^\s*"acct"<blob>="(.*)"\s*$`)
+
+// macKeychainAccount reads an item's own account name back from the
+// keychain, returning "" when it cannot be determined.
+//
+// This matters because `security add-generic-password -U` matches on the
+// (service, account) pair: writing under the wrong account name creates a
+// *second* item beside the real one, exits 0, and leaves Claude Code still
+// reading the original — a switch that reports success and changes nothing
+// (issue #42). Note that `find-generic-password` reports only the first
+// match for a service, so a machine that already accumulated duplicates
+// from that bug needs them removed by hand.
+func macKeychainAccount(service string) string {
+	out, err := exec.Command("security", "find-generic-password",
+		"-s", service).Output()
+	if err != nil {
+		return ""
+	}
+	return parseKeychainAccount(string(out))
+}
+
+func parseKeychainAccount(dump string) string {
+	m := keychainAcctRe.FindStringSubmatch(dump)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
 func writeLiveMacOS(blob string) error {
-	user := os.Getenv("USER")
+	// Write into whichever item the read path selects, so a switch lands
+	// where Claude Code is actually looking. Falling back to the classic
+	// service only when nothing exists keeps a first-ever write working.
+	service := macKeychainServices[0]
+	account := ""
+	if items, err := findMacKeychainItems(); err == nil {
+		if it, _ := selectLiveItem(items); it.service != "" {
+			service = it.service
+			account = macKeychainAccount(service)
+		}
+	}
+	if account == "" {
+		account = os.Getenv("USER")
+	}
 	cmd := exec.Command("security", "add-generic-password",
 		"-U", // update if already present
-		"-s", macKeychainService,
-		"-a", user,
+		"-s", service,
+		"-a", account,
 		"-w", blob,
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("creds: security add: %w (%s)", err, out)
+		return fmt.Errorf("creds: security add %q: %w (%s)", service, err, out)
 	}
 	return nil
 }
@@ -397,10 +590,13 @@ func readBackupKeychainMacOS(slot int, email string) (string, error) {
 		"-wa", backupKeyringUser(slot, email))
 	out, err := cmd.Output()
 	if err != nil {
-		// `security` returns exit 44 when the item isn't found.
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
-			return "", ErrNotFound
+			if ee.ExitCode() == keychainExitNotFound {
+				return "", ErrNotFound
+			}
+			return "", fmt.Errorf("creds: security find backup: exit %d: %s",
+				ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
 		}
 		return "", fmt.Errorf("creds: security find backup: %w", err)
 	}

--- a/internal/creds/creds_test.go
+++ b/internal/creds/creds_test.go
@@ -1,6 +1,182 @@
 package creds
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/inulute/cux/internal/paths"
+)
+
+// The blobs a real install produces: the managed item owns the account
+// login, the classic item is left with only the MCP block (issue #42).
+const (
+	accountBlob = `{"claudeAiOauth":{"accessToken":"tok","refreshToken":"r"}}`
+	mcpOnlyBlob = `{"mcpOAuth":{"some-server":{"accessToken":"not-an-account-token"}}}`
+)
+
+func TestSelectLiveItemPicksTheItemHoldingTheAccountToken(t *testing.T) {
+	cases := []struct {
+		name        string
+		items       []macKeychainItem
+		wantService string
+		wantErr     error
+	}{
+		{
+			name:        "single classic item, the common install",
+			items:       []macKeychainItem{{service: "Claude Code-credentials", blob: accountBlob}},
+			wantService: "Claude Code-credentials",
+		},
+		{
+			// The #42 case: the classic item exists and looks fine to a
+			// name-based lookup, but the token is in the managed item.
+			name: "classic item is MCP-only, managed item has the token",
+			items: []macKeychainItem{
+				{service: "Claude Code-credentials", blob: mcpOnlyBlob},
+				{service: "Orca Claude Code Managed Credentials", blob: accountBlob},
+			},
+			wantService: "Orca Claude Code Managed Credentials",
+		},
+		{
+			// Order must not become a preference: a machine where the
+			// classic item still holds the login keeps using it.
+			name: "both items exist and the classic one has the token",
+			items: []macKeychainItem{
+				{service: "Claude Code-credentials", blob: accountBlob},
+				{service: "Orca Claude Code Managed Credentials", blob: mcpOnlyBlob},
+			},
+			wantService: "Claude Code-credentials",
+		},
+		{
+			name:    "no items at all",
+			items:   nil,
+			wantErr: ErrNotFound,
+		},
+		{
+			// Nothing to read, but the write path still needs somewhere to
+			// restore into, so the first existing item comes back with it.
+			name:        "items exist but none holds a token",
+			items:       []macKeychainItem{{service: "Claude Code-credentials", blob: mcpOnlyBlob}},
+			wantService: "Claude Code-credentials",
+			wantErr:     ErrNoAccountToken,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := selectLiveItem(c.items)
+			if !errors.Is(err, c.wantErr) {
+				t.Fatalf("selectLiveItem error = %v, want %v", err, c.wantErr)
+			}
+			if got.service != c.wantService {
+				t.Errorf("selectLiveItem service = %q, want %q", got.service, c.wantService)
+			}
+		})
+	}
+}
+
+func TestExtractAccessTokenDistinguishesMissingFromTokenless(t *testing.T) {
+	if _, err := ExtractAccessToken(""); !errors.Is(err, ErrNotFound) {
+		t.Errorf("empty blob: got %v, want ErrNotFound", err)
+	}
+	// The whole point of the split: "found, but not a login" must not
+	// report itself as "not found" (issue #42).
+	_, err := ExtractAccessToken(mcpOnlyBlob)
+	if !errors.Is(err, ErrNoAccountToken) {
+		t.Errorf("MCP-only blob: got %v, want ErrNoAccountToken", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("MCP-only blob must not also satisfy errors.Is(err, ErrNotFound)")
+	}
+	tok, err := ExtractAccessToken(accountBlob)
+	if err != nil || tok != "tok" {
+		t.Errorf("account blob: got (%q, %v), want (\"tok\", nil)", tok, err)
+	}
+}
+
+func TestWriteRefusesBlobsThatWouldSignTheUserOut(t *testing.T) {
+	// The guard rejects before any backend is reached, but isolate anyway so
+	// a later refactor cannot turn this test into a write to the developer's
+	// real keychain (issue #7).
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("CUX_CREDS_BACKEND", "file")
+
+	for _, blob := range []string{mcpOnlyBlob, `{}`, `{"claudeAiOauth":{}}`} {
+		if err := WriteLive(blob); !errors.Is(err, ErrNoAccountToken) {
+			t.Errorf("WriteLive(%s) = %v, want ErrNoAccountToken", blob, err)
+		}
+		if err := WriteBackup(1, "a@x.test", blob); !errors.Is(err, ErrNoAccountToken) {
+			t.Errorf("WriteBackup(%s) = %v, want ErrNoAccountToken", blob, err)
+		}
+	}
+	// Empty stays its own, older error — it never reached storage anyway.
+	if err := WriteLive(""); err == nil || errors.Is(err, ErrNoAccountToken) {
+		t.Errorf("WriteLive(\"\") = %v, want the empty-credentials error", err)
+	}
+}
+
+// ReadLive must answer the same way on every backend. The macOS path gets
+// there by selecting on content; the file path needs the check in ReadLive
+// itself, or Linux and Windows would hand a tokenless blob to callers and
+// fail later, during an add, instead of here.
+func TestReadLiveFileBackendReportsTokenlessCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("CUX_CREDS_BACKEND", "file")
+
+	if _, err := ReadLive(); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("no credentials file: got %v, want ErrNotFound", err)
+	}
+
+	// Written directly: WriteLive itself refuses this blob now.
+	if err := os.MkdirAll(paths.ClaudeDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ClaudeCredentials(), []byte(mcpOnlyBlob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadLive(); !errors.Is(err, ErrNoAccountToken) {
+		t.Fatalf("MCP-only credentials file: got %v, want ErrNoAccountToken", err)
+	}
+
+	if err := os.WriteFile(paths.ClaudeCredentials(), []byte(accountBlob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadLive()
+	if err != nil || got != accountBlob {
+		t.Fatalf("valid credentials file: got (%q, %v), want the blob and nil", got, err)
+	}
+}
+
+func TestParseKeychainAccount(t *testing.T) {
+	// Real `security find-generic-password` output, trimmed. The svce line
+	// is included because a filtered dump interleaves acct and svce lines
+	// from different items — this parser only ever sees one item's dump.
+	const dump = `keychain: "/Users/x/Library/Keychains/login.keychain-db"
+class: "genp"
+attributes:
+    0x00000007 <blob>=<NULL>
+    "acct"<blob>="someone"
+    "mdat"<timedate>=0x32303236303830345A00  "20260804Z\000"
+    "svce"<blob>="Claude Code-credentials"
+`
+	if got := parseKeychainAccount(dump); got != "someone" {
+		t.Errorf("parseKeychainAccount = %q, want %q", got, "someone")
+	}
+	// A NULL or hex-encoded acct must yield "" so the caller falls back to
+	// $USER rather than writing under a mangled account name.
+	for _, in := range []string{
+		`    "acct"<blob>=<NULL>` + "\n",
+		`    "acct"<blob>=0x736F6D65  "some"` + "\n",
+		"attributes:\n",
+	} {
+		if got := parseKeychainAccount(in); got != "" {
+			t.Errorf("parseKeychainAccount(%q) = %q, want \"\"", strings.TrimSpace(in), got)
+		}
+	}
+}
 
 func TestDecodeBackupValue(t *testing.T) {
 	const blob = `{"claudeAiOauth":{}}`

--- a/internal/creds/keychain_darwin_test.go
+++ b/internal/creds/keychain_darwin_test.go
@@ -1,0 +1,190 @@
+//go:build darwin
+
+package creds
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Round-trip tests against the real macOS keychain, reproducing the issue #42
+// layout: two credentials items, where the one cux used to look up by name
+// holds only the MCP block and the account login lives in the other.
+//
+// These write to the login keychain, so they are opt-in: set
+// CUX_TEST_REAL_KEYCHAIN=1 to run them. Items are created under
+// cux-test-* service names — never Claude Code's own — and removed on
+// cleanup. macOS may prompt for keychain access the first time.
+const envRealKeychainTests = "CUX_TEST_REAL_KEYCHAIN"
+
+const (
+	testServiceClassic = "cux-test-classic-credentials"
+	testServiceManaged = "cux-test-managed-credentials"
+	// Deliberately not $USER: the account name is what `add-generic-password
+	// -U` matches on, so a write that assumes $USER lands in a new item
+	// instead of this one.
+	testAcctClassic = "cux-test-acct-classic"
+	testAcctManaged = "cux-test-acct-managed"
+)
+
+func requireRealKeychain(t *testing.T) {
+	t.Helper()
+	if os.Getenv(envRealKeychainTests) == "" {
+		t.Skipf("set %s=1 to run tests that write to the real keychain", envRealKeychainTests)
+	}
+	// The keychain path is only taken when the file backend is not forced.
+	t.Setenv(envCredsBackend, "")
+}
+
+func addTestKeychainItem(t *testing.T, service, account, blob string) {
+	t.Helper()
+	out, err := exec.Command("security", "add-generic-password",
+		"-U", "-s", service, "-a", account, "-w", blob).CombinedOutput()
+	if err != nil {
+		t.Fatalf("seeding %s: %v (%s)", service, err, out)
+	}
+	t.Cleanup(func() {
+		// Remove every item under this service, so a duplicate created by a
+		// regression is cleaned up too rather than left behind.
+		for {
+			if err := exec.Command("security", "delete-generic-password",
+				"-s", service).Run(); err != nil {
+				return
+			}
+		}
+	})
+}
+
+func readTestKeychainItem(t *testing.T, service string) string {
+	t.Helper()
+	blob, err := readMacKeychainSecret(service)
+	if err != nil {
+		t.Fatalf("reading back %s: %v", service, err)
+	}
+	return blob
+}
+
+// itemExistsForAccount reports whether an item exists under this exact
+// (service, account) pair — the pair `-U` matches on. Used to prove a write
+// updated the existing item instead of creating a second one beside it.
+func itemExistsForAccount(service, account string) bool {
+	err := exec.Command("security", "find-generic-password",
+		"-s", service, "-a", account).Run()
+	return err == nil
+}
+
+func TestRealKeychainSelectsAndWritesTheItemHoldingTheLogin(t *testing.T) {
+	requireRealKeychain(t)
+
+	// The #42 layout: the item cux looked up by name has no account token.
+	addTestKeychainItem(t, testServiceClassic, testAcctClassic, mcpOnlyBlob)
+	addTestKeychainItem(t, testServiceManaged, testAcctManaged, accountBlob)
+
+	restore := macKeychainServices
+	macKeychainServices = []string{testServiceClassic, testServiceManaged}
+	t.Cleanup(func() { macKeychainServices = restore })
+
+	// Confirm the trap the old code fell into is really set up: a name-only
+	// lookup of the first service succeeds and yields no account token.
+	if blob := readTestKeychainItem(t, testServiceClassic); hasAccountToken(blob) {
+		t.Fatal("fixture is wrong: the classic item should have no account token")
+	}
+
+	// Read: selection must cross to the second item.
+	items, err := findMacKeychainItems()
+	if err != nil {
+		t.Fatalf("findMacKeychainItems: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("found %d items, want 2", len(items))
+	}
+	selected, err := selectLiveItem(items)
+	if err != nil {
+		t.Fatalf("selectLiveItem: %v", err)
+	}
+	if selected.service != testServiceManaged {
+		t.Errorf("selected %q, want %q", selected.service, testServiceManaged)
+	}
+	got, err := ReadLive()
+	if err != nil || got != accountBlob {
+		t.Fatalf("ReadLive = (%q, %v), want the account blob and nil", got, err)
+	}
+
+	// The account name must come back from the item itself, not $USER.
+	if acct := macKeychainAccount(testServiceManaged); acct != testAcctManaged {
+		t.Errorf("macKeychainAccount = %q, want %q", acct, testAcctManaged)
+	}
+
+	// Write: must land in the item holding the login, under its own account.
+	const updated = `{"claudeAiOauth":{"accessToken":"tok2","refreshToken":"r2"}}`
+	if err := WriteLive(updated); err != nil {
+		t.Fatalf("WriteLive: %v", err)
+	}
+	if blob := readTestKeychainItem(t, testServiceManaged); blob != updated {
+		t.Errorf("managed item = %q, want the updated blob", blob)
+	}
+	// The MCP-only item must be untouched — cux used to overwrite it, which
+	// destroyed the MCP OAuth state on an affected machine.
+	if blob := readTestKeychainItem(t, testServiceClassic); blob != mcpOnlyBlob {
+		t.Errorf("classic item = %q, want it untouched", blob)
+	}
+	// No duplicate: nothing may exist under (managed service, $USER).
+	if user := os.Getenv("USER"); user != "" && user != testAcctManaged {
+		if itemExistsForAccount(testServiceManaged, user) {
+			t.Errorf("write created a duplicate item under acct %q instead of updating acct %q", user, testAcctManaged)
+		}
+	}
+	if !itemExistsForAccount(testServiceManaged, testAcctManaged) {
+		t.Errorf("item under acct %q disappeared", testAcctManaged)
+	}
+
+	// And the guard holds against the real backend: an MCP-only blob must
+	// not reach the keychain, or it would sign the user out.
+	if err := WriteLive(mcpOnlyBlob); !errors.Is(err, ErrNoAccountToken) {
+		t.Errorf("WriteLive(mcp-only) = %v, want ErrNoAccountToken", err)
+	}
+	if blob := readTestKeychainItem(t, testServiceManaged); blob != updated {
+		t.Errorf("refused write still changed the item: %q", blob)
+	}
+}
+
+// A first-ever write, with no item present, must create one under the
+// primary service so a fresh install still works.
+func TestRealKeychainFirstWriteCreatesPrimaryItem(t *testing.T) {
+	requireRealKeychain(t)
+
+	restore := macKeychainServices
+	macKeychainServices = []string{testServiceClassic, testServiceManaged}
+	t.Cleanup(func() { macKeychainServices = restore })
+	t.Cleanup(func() {
+		for {
+			if err := exec.Command("security", "delete-generic-password",
+				"-s", testServiceClassic).Run(); err != nil {
+				return
+			}
+		}
+	})
+
+	if _, err := ReadLive(); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("precondition: ReadLive = %v, want ErrNotFound (leftover test item?)", err)
+	}
+	if err := WriteLive(accountBlob); err != nil {
+		t.Fatalf("WriteLive: %v", err)
+	}
+	if blob := readTestKeychainItem(t, testServiceClassic); blob != accountBlob {
+		t.Errorf("primary item = %q, want the account blob", blob)
+	}
+	// With nothing to read an account name from, $USER is the fallback.
+	if user := os.Getenv("USER"); user != "" {
+		if acct := macKeychainAccount(testServiceClassic); acct != user {
+			t.Errorf("macKeychainAccount = %q, want $USER %q", acct, user)
+		}
+	}
+	got, err := ReadLive()
+	if err != nil || !strings.Contains(got, "tok") {
+		t.Fatalf("ReadLive after first write = (%q, %v)", got, err)
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -3,6 +3,8 @@ package hooks
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,12 +140,24 @@ func TestHandleAutoSwitchPrompt_HardBlock_Threshold100(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// RefreshAll runs inside the hook, so point the usage API at a local
+	// server that always fails. The seeded cache below then survives the
+	// refresh — refreshOne returns the fetch error without caching — which
+	// is what this test needs, and it stays hermetic.
+	//
+	// This used to be achieved with a credential blob that had no
+	// accessToken, so refreshOne bailed before the API call. That blob is no
+	// longer writable: creds.WriteLive refuses credentials with no account
+	// token, because writing them over a live login silently signs the user
+	// out (issue #42).
+	apiDown := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "usage endpoint unavailable in test", http.StatusInternalServerError)
+	}))
+	defer apiDown.Close()
+	t.Setenv("CUX_USAGE_ENDPOINT", apiDown.URL)
+
 	// Backup credentials for slot 2 (target account). The hook calls
 	// switcher.SwitchTo directly, which reads these files to swap creds.
-	// The credential blob intentionally omits "accessToken" so that
-	// RefreshAll's refreshOne call hits ExtractAccessToken error and
-	// returns before making a real API call — avoiding a 401 that would
-	// mark the account as TokenExpired and prevent PickNext from selecting it.
 	// Resolve the directory through paths.AccountDir rather than
 	// hand-building it: the backup root differs per platform (XDG on
 	// Linux, ~/.cux elsewhere) and a hardcoded layout only matched Linux.
@@ -151,7 +165,7 @@ func TestHandleAutoSwitchPrompt_HardBlock_Threshold100(t *testing.T) {
 	if err := os.MkdirAll(acct2Dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	fakeCreds := `{"cux-test-slot":"2"}` // no accessToken → no API call
+	fakeCreds := `{"cux-test-slot":"2","claudeAiOauth":{"accessToken":"test-token-2"}}`
 	if err := os.WriteFile(filepath.Join(acct2Dir, "credentials.json"), []byte(fakeCreds), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/switcher/switcher.go
+++ b/internal/switcher/switcher.go
@@ -50,6 +50,17 @@ func AddCurrent(preferredSlot int, alias string, skipAutoAlias bool) (added stor
 		if errors.Is(err, creds.ErrNotFound) {
 			return store.Account{}, false, errors.New("no active Claude Code login found — run `claude login` first")
 		}
+		if errors.Is(err, creds.ErrNoAccountToken) {
+			// Credentials exist but hold no account token: the login is
+			// stored somewhere cux does not know about (issue #42). Capturing
+			// it anyway would build a slot that signs the user out later, so
+			// stop here and say what was actually found.
+			return store.Account{}, false, errors.New(
+				"Claude Code's stored credentials carry no account token, so there is nothing to capture — " +
+					"the login may be held by a credential provider cux does not recognise. " +
+					"Run `claude login`, then retry; if it persists, please report your Claude Code version at " +
+					"https://github.com/inulute/cux/issues")
+		}
 		return store.Account{}, false, err
 	}
 
@@ -175,6 +186,18 @@ func SwitchTo(identifier string) (from, to store.Account, err error) {
 	targetCreds, err := creds.ReadBackup(target.Slot, target.Email)
 	if err != nil {
 		return store.Account{}, store.Account{}, fmt.Errorf("target credentials missing: %w", err)
+	}
+	// A slot captured while cux was reading the wrong keychain item holds a
+	// blob with no account token (issue #42). Writing it live would sign the
+	// user out, and creds.WriteLive now refuses to — but refusing at the
+	// bottom of the stack only produces a confusing message, so say what is
+	// wrong with the slot and how to repair it while we still know which one
+	// it is.
+	if _, tokErr := creds.ExtractAccessToken(targetCreds); tokErr != nil {
+		return store.Account{}, store.Account{}, fmt.Errorf(
+			"slot %d (%s) has no usable stored login: its saved credentials carry no account token, "+
+				"so switching to it would sign you out — run `claude login` as %s, then `cux add` to recapture the slot",
+			target.Slot, target.Email, target.Email)
 	}
 	targetOAuth, err := store.ReadOAuthBlockBackup(target.Slot, target.Email)
 	if err != nil {


### PR DESCRIPTION
Fixes #42.

## The read bug

Some macOS installs carry a second credentials item beside the classic one — the name suggests managed/enterprise provisioning — and then the account login lives there while `Claude Code-credentials` is left holding only the `mcpOAuth` block. `readLiveMacOS` asked for the classic service by name, `security` exited 0, and the MCP-only blob went on to `ExtractAccessToken`, which reported missing credentials for an account that was logged in and working.

The live item is now chosen by **content**: the first one whose blob actually carries `claudeAiOauth.accessToken`. Order is not a preference, so a machine where the classic item still holds the login keeps using it.

## The error that pointed the wrong way

`ErrNotFound` meant both "no such item" and "item found, but it is not a login", which sends a user hunting for a missing keychain entry instead of an unexpected one. The second case is now `ErrNoAccountToken`, and `ReadLive` applies the check above the platform dispatch so the file backends answer identically rather than handing a tokenless blob to a caller and failing later, during an add.

## The write bug

`security add-generic-password -U` matches on the **(service, account)** pair. Writing under `$USER` when the target item has a different account name created a second item beside the real one, exited 0, and left Claude Code reading the original — a switch that reported success and changed nothing.

Writes now go to the item the read path selected, under that item's own `acct` read back from the keychain. Only the quoted attribute form is accepted; `<NULL>` and hex fall back to `$USER` rather than writing under a mangled name. On an affected machine this also stops cux overwriting the classic item, so MCP OAuth state survives a switch.

## The silent logout

A slot captured while this bug was present holds a blob with no account token, and writing it live signs the user out with nothing visible to explain it. `WriteLive` and `WriteBackup` now refuse such a blob on every platform, and both ends of the loop explain the repair:

- `cux add` — says the stored credentials are not a login and that a provider cux does not recognise may hold it.
- `cux switch` — names the slot and says to `claude login` as that account, then `cux add` to recapture it.

Also: only `security` exit 44 now means "absent", so a denied prompt or a locked keychain surfaces as itself instead of as "not logged in".

## Verification

Round-trip tests against a real keychain build the same layout under `cux-test-*` service names: an MCP-only item ahead of the item holding the login, under an `acct` that is deliberately not `$USER`. Both halves were confirmed to fail when reverted:

- revert content-based selection → `selected "cux-test-classic-credentials"`, `ReadLive` → `ErrNoAccountToken`
- revert the `acct` lookup → `WriteLive` reports **success**, the item still holds the **old** token, and a duplicate appears under `$USER` — the symptom from the report

They also assert the MCP-only item is left byte-identical after a write, that a refused write changes nothing, and that a first write with no items present still creates one under the primary service. These write to the login keychain, so they are opt-in behind `CUX_TEST_REAL_KEYCHAIN=1` and skip by default.

## Not verified

The reporter confirmed their own patch restores `cux add` and `cux usage refresh` — both read-side. Nobody has yet confirmed `security add-generic-password -U` succeeds against an item provisioned by a genuinely managed credential provider: ACLs may reject the write, or the provider may re-provision over it. The test above uses a `cux-test-*` stand-in of the same shape, not a real managed item. Errors surface with `security`'s own output, so this fails loudly rather than silently, but `cux switch` on an affected machine is still worth a confirmation before this is called closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
