### PR TITLE
wrapper+hooks: migrate idle sessions off over-threshold accounts (#39)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -37,7 +37,18 @@
       "Bash(go clean *)",
       "Bash(/tmp/cux-test --version)",
       "Bash(gh issue *)",
-      "Bash(node *)"
+      "Bash(node *)",
+      "Bash(cd *)",
+      "Bash(cux history *)",
+      "Bash(awk '/func \\\\\\(h \\\\*Host\\\\\\) Pump/,/^}/' internal/ptyhost/ptyhost.go)",
+      "Bash(awk '/func \\\\\\(h \\\\*Host\\\\\\) broadcast/,/^}/' internal/ptyhost/ptyhost.go)",
+      "Bash(gh pr *)",
+      "Bash(git fetch *)",
+      "Bash(git worktree *)",
+      "Bash(git pull *)",
+      "Bash(grep -nA6 'type clientState struct' internal/ptyhost/ptyhost.go)",
+      "Bash(git checkout *)",
+      "Bash(git add *)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ cux config set update_check.enabled true            # opt in to update checks
 | `strategy.order`              | `[]`           | Drain mode priority (emails); empty = auto by highest 7d |
 | `auto_switch_on_threshold`    | `true`         | Master toggle for pre-emptive threshold swap |
 | `auto_switch_on_rate_limit`   | `true`         | Master toggle for swap on rate-limit hook |
+| `auto_swap_idle_after_seconds`| `900`          | Migrate a session idle this long off an over-threshold account, instead of waiting for you to come back and type. `0` = off. Needs `auto_resume`. |
 | `auto_resume`                 | `true`         | Pass `--resume <id>` to the relaunched claude |
 | `auto_message`                | `Go continue.` | First user turn after auto-swap; `""` = silent |
 | `wait_for_reset`              | `true`         | When every account is exhausted, sleep until the earliest reset and resume |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,18 +59,22 @@ type UpdateCheckConfig struct {
 // the right knobs when you want auto-swap off but `/switch` rotation
 // to keep working.
 type Config struct {
-	Thresholds            usage.Thresholds  `json:"thresholds"`
-	Strategy              StrategyConfig    `json:"strategy"`
-	AutoSwitchOnThreshold bool              `json:"auto_switch_on_threshold"`
-	AutoSwitchOnRateLimit bool              `json:"auto_switch_on_rate_limit"`
-	AutoResume            bool              `json:"auto_resume"`
-	AutoMessage           string            `json:"auto_message"`
-	WaitForReset          bool              `json:"wait_for_reset"`
-	RetryOnAPIError       bool              `json:"retry_on_api_error"`
-	Notify                bool              `json:"notify"`
-	PollIntervalSeconds   int               `json:"poll_interval_seconds"`
-	UpdateCheck           UpdateCheckConfig `json:"update_check"`
-	Theme                 string            `json:"theme"`
+	Thresholds            usage.Thresholds `json:"thresholds"`
+	Strategy              StrategyConfig   `json:"strategy"`
+	AutoSwitchOnThreshold bool             `json:"auto_switch_on_threshold"`
+	AutoSwitchOnRateLimit bool             `json:"auto_switch_on_rate_limit"`
+	AutoResume            bool             `json:"auto_resume"`
+	AutoMessage           string           `json:"auto_message"`
+	WaitForReset          bool             `json:"wait_for_reset"`
+	RetryOnAPIError       bool             `json:"retry_on_api_error"`
+	Notify                bool             `json:"notify"`
+	PollIntervalSeconds   int              `json:"poll_interval_seconds"`
+	// AutoSwapIdleAfterSeconds migrates a session that is sitting at an
+	// empty prompt off an over-threshold account, instead of waiting for
+	// its owner to come back and type. 0 disables it. See #39.
+	AutoSwapIdleAfterSeconds int               `json:"auto_swap_idle_after_seconds"`
+	UpdateCheck              UpdateCheckConfig `json:"update_check"`
+	Theme                    string            `json:"theme"`
 	// Attach exposes each session on a local Unix socket so `cux attach`
 	// (and compatible tools) can mirror the terminal; AttachInput
 	// additionally lets attached clients type into the session.
@@ -98,8 +102,13 @@ func Defaults() Config {
 		RetryOnAPIError:       true,
 		Notify:                true,
 		PollIntervalSeconds:   60,
-		UpdateCheck:           UpdateCheckConfig{Enabled: true, CadenceHours: 6},
-		Theme:                 "claude",
+		// 15 minutes: long enough that a user reading output or thinking
+		// between prompts is never treated as gone, short enough that a
+		// terminal left overnight moves off a capped seat during the quiet
+		// hours rather than on the prompt that starts real work (#39).
+		AutoSwapIdleAfterSeconds: 900,
+		UpdateCheck:              UpdateCheckConfig{Enabled: true, CadenceHours: 6},
+		Theme:                    "claude",
 		// Off by default: an always-on PTY proxy taxes every session
 		// (resize corruption/jitter, extra CPU on output — see #33). Most
 		// users never attach, so keep claude sitting directly on the real
@@ -268,6 +277,12 @@ func Set(c Config, key, value string) (Config, error) {
 			return c, fmt.Errorf("config: poll_interval_seconds must be a non-negative integer, got %q", value)
 		}
 		c.PollIntervalSeconds = n
+	case "auto_swap_idle_after_seconds":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return c, fmt.Errorf("config: auto_swap_idle_after_seconds must be a non-negative integer, got %q", value)
+		}
+		c.AutoSwapIdleAfterSeconds = n
 	case "theme":
 		v := strings.ToLower(strings.TrimSpace(value))
 		switch v {
@@ -357,6 +372,11 @@ func Keys(c Config) []KeyInfo {
 			Key: "poll_interval_seconds", Default: "60",
 			Description: "background usage poll interval (reserved for v0.3)",
 			Current:     strconv.Itoa(c.PollIntervalSeconds),
+		},
+		{
+			Key: "auto_swap_idle_after_seconds", Default: "900",
+			Description: "migrate a session idle this long off an over-threshold account (0 = off)",
+			Current:     strconv.Itoa(c.AutoSwapIdleAfterSeconds),
 		},
 		{
 			Key: "update_check.enabled", Default: "false",

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -110,18 +110,40 @@ func UserPromptSubmit(stdin io.Reader, stdout io.Writer) error {
 	if prompt == "" {
 		return nil
 	}
+	// Every branch below reports the prompt to the wrapper, which uses it
+	// as the "a human is here" clock for idle migration (#39). Only the
+	// fall-through at the end starts a model turn; the branches that handle
+	// the prompt themselves block it, so no Stop ever follows them.
 	if prompt == "/switch" || strings.HasPrefix(prompt, "/switch ") {
+		notePromptSubmitted(false)
 		target := strings.TrimSpace(strings.TrimPrefix(prompt, "/switch"))
 		writePromptSwitch(target, stdout)
 		return nil
 	}
 	if handled, err := handleCuxPromptCommand(prompt, stdout); handled || err != nil {
+		notePromptSubmitted(false)
 		return err
 	}
 	if handled, err := handleAutoSwitchPrompt(prompt, stdout); handled || err != nil {
+		notePromptSubmitted(false)
 		return err
 	}
+	notePromptSubmitted(true)
 	return nil
+}
+
+// notePromptSubmitted tells the wrapper the user just typed something.
+// Best-effort by design: a failed write must never block the prompt, it
+// only costs this session an idle migration it might otherwise have got.
+func notePromptSubmitted(startsTurn bool) {
+	pid, err := wrapperPID()
+	if err != nil {
+		return
+	}
+	_ = signals.Write(pid, signals.PromptSubmitted, signals.PromptSubmittedPayload{
+		Timestamp:  time.Now().UTC(),
+		StartsTurn: startsTurn,
+	})
 }
 
 func UserPromptExpansion(stdin io.Reader, stdout io.Writer) error {

--- a/internal/hooks/promptsubmitted_test.go
+++ b/internal/hooks/promptsubmitted_test.go
@@ -1,0 +1,124 @@
+package hooks
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/inulute/cux/internal/signals"
+	"github.com/inulute/cux/internal/store"
+)
+
+// The wrapper's idle migration hinges on StartsTurn: a prompt the hook
+// handles itself is blocked and never reaches the model, so no Stop will
+// follow it. Recording one as the start of a turn would leave the session
+// looking permanently busy and it would never migrate (#39).
+func TestUserPromptSubmitReportsPromptsToTheWrapper(t *testing.T) {
+	cases := []struct {
+		name           string
+		prompt         string
+		wantSignal     bool
+		wantStartsTurn bool
+	}{
+		{
+			name:           "an ordinary prompt goes to the model",
+			prompt:         "refactor the parser",
+			wantSignal:     true,
+			wantStartsTurn: true,
+		},
+		{
+			// Handled by the hook: user is present, but no turn starts.
+			name:           "/switch is handled by the hook",
+			prompt:         "/switch work",
+			wantSignal:     true,
+			wantStartsTurn: false,
+		},
+		{
+			// Not a prompt at all — nothing to report.
+			name:       "empty prompt reports nothing",
+			prompt:     "   ",
+			wantSignal: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("CUX_WRAPPED", "1")
+			t.Setenv("CUX_WRAPPER_PID", "424242")
+			t.Setenv("HOME", tmp)
+			t.Setenv("XDG_DATA_HOME", tmp)
+			t.Setenv("CUX_CREDS_BACKEND", "file")
+			t.Setenv("CUX_CONFIG_FILE", filepath.Join(tmp, "config.json"))
+
+			// A minimal state file so the /switch path has somewhere to look
+			// instead of erroring before it reports the prompt.
+			state := &store.State{
+				ActiveSlot: 1,
+				Sequence:   []int{1},
+				Accounts:   map[int]store.Account{1: {Slot: 1, Email: "a@x.test", Alias: "work"}},
+			}
+			if err := state.Save(); err != nil {
+				t.Fatal(err)
+			}
+
+			var out bytes.Buffer
+			body := `{"prompt":` + jsonString(c.prompt) + `}`
+			if err := UserPromptSubmit(strings.NewReader(body), &out); err != nil {
+				t.Fatalf("UserPromptSubmit: %v", err)
+			}
+
+			b, ok, _ := signals.Read(424242, signals.PromptSubmitted)
+			if ok != c.wantSignal {
+				t.Fatalf("signal written = %v, want %v", ok, c.wantSignal)
+			}
+			if !c.wantSignal {
+				return
+			}
+			p, err := signals.DecodePromptSubmitted(b)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if p.StartsTurn != c.wantStartsTurn {
+				t.Errorf("StartsTurn = %v, want %v", p.StartsTurn, c.wantStartsTurn)
+			}
+			if p.Timestamp.IsZero() {
+				t.Error("Timestamp is zero; the wrapper needs it for the idle clock")
+			}
+		})
+	}
+}
+
+// An unwrapped session (plain `claude`, no cux) must stay silent.
+func TestUserPromptSubmitReportsNothingWhenUnwrapped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CUX_WRAPPED", "")
+	t.Setenv("CUX_WRAPPER_PID", "424243")
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	var out bytes.Buffer
+	if err := UserPromptSubmit(strings.NewReader(`{"prompt":"hello"}`), &out); err != nil {
+		t.Fatalf("UserPromptSubmit: %v", err)
+	}
+	if _, ok, _ := signals.Read(424243, signals.PromptSubmitted); ok {
+		t.Error("unwrapped session must not write signals")
+	}
+}
+
+func jsonString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/signals/signals.go
+++ b/internal/signals/signals.go
@@ -37,6 +37,7 @@ const (
 	RateLimited     Name = "rate-limited"
 	SwitchRequested Name = "switch-requested"
 	TurnFailed      Name = "turn-failed"
+	PromptSubmitted Name = "prompt-submitted"
 )
 
 // Payloads. Match claude-revolver's shapes for hook-emitted signals so
@@ -72,6 +73,19 @@ type SwitchRequestedPayload struct {
 type TurnFailedPayload struct {
 	Timestamp time.Time `json:"timestamp"`
 	Message   string    `json:"message,omitempty"`
+}
+
+// PromptSubmittedPayload marks the user typing something — the wrapper's
+// only evidence that a human is present, since nothing else it observes
+// distinguishes a session parked at an empty prompt from one mid-turn.
+//
+// StartsTurn is false for a prompt the hook handled itself (a /switch, a
+// /cux:* command, an intercepted threshold swap): those never reach the
+// model, so no Stop will follow them. Treating one as the start of a turn
+// would leave the session looking busy forever.
+type PromptSubmittedPayload struct {
+	Timestamp  time.Time `json:"timestamp"`
+	StartsTurn bool      `json:"startsTurn"`
 }
 
 // Dir returns the absolute signal directory. Callers that intend to
@@ -163,6 +177,16 @@ func DecodeSessionStarted(b []byte) (SessionStartedPayload, error) {
 // DecodeStopped is a convenience for the wrapper.
 func DecodeStopped(b []byte) (StoppedPayload, error) {
 	var p StoppedPayload
+	if len(b) == 0 {
+		return p, nil
+	}
+	err := json.Unmarshal(b, &p)
+	return p, err
+}
+
+// DecodePromptSubmitted is a convenience for the wrapper.
+func DecodePromptSubmitted(b []byte) (PromptSubmittedPayload, error) {
+	var p PromptSubmittedPayload
 	if len(b) == 0 {
 		return p, nil
 	}

--- a/internal/wrapper/idleswap_test.go
+++ b/internal/wrapper/idleswap_test.go
@@ -1,0 +1,196 @@
+package wrapper
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/inulute/cux/internal/config"
+)
+
+func idleTestConfig() *config.Config {
+	c := config.Defaults()
+	c.AutoSwapIdleAfterSeconds = 900
+	c.AutoSwitchOnThreshold = true
+	c.AutoResume = true
+	return &c
+}
+
+// idleFor is the guard that separates "parked at an empty prompt" from
+// "twenty minutes into a turn". Without it a long tool call reads as idle
+// and the migration kills live work.
+func TestActivityIdleForNeverReportsATurnInFlightAsIdle(t *testing.T) {
+	start := time.Now()
+	act := newActivity(start)
+	long := start.Add(30 * time.Minute)
+
+	if d, ok := act.idleFor(long); !ok || d < 30*time.Minute {
+		t.Fatalf("untouched session: idleFor = (%v, %v), want ~30m and ok", d, ok)
+	}
+
+	// A prompt that reached the model. However long it runs, not idle.
+	act.lastAt = start
+	act.turnInFlight = true
+	if _, ok := act.idleFor(long); ok {
+		t.Error("a turn in flight must never be reported as idle")
+	}
+
+	// The Stop that ends it makes the session idle-eligible again.
+	act.turnInFlight = false
+	act.lastAt = long
+	if d, ok := act.idleFor(long.Add(20 * time.Minute)); !ok || d < 20*time.Minute {
+		t.Errorf("after turn end: idleFor = (%v, %v), want ~20m and ok", d, ok)
+	}
+}
+
+func TestIdleSwapDue(t *testing.T) {
+	const window = 900 * time.Second
+
+	cases := []struct {
+		name    string
+		mutate  func(*config.Config)
+		prepare func(*activity)
+		swap    *pending
+		want    bool
+	}{
+		{
+			name:    "idle past the window",
+			prepare: func(a *activity) { a.lastAt = time.Now().Add(-window - time.Minute) },
+			want:    true,
+		},
+		{
+			name:    "idle but not yet past the window",
+			prepare: func(a *activity) { a.lastAt = time.Now().Add(-window / 2) },
+			want:    false,
+		},
+		{
+			// The gate that matters most: a long turn is not an idle session.
+			name: "long turn in flight",
+			prepare: func(a *activity) {
+				a.lastAt = time.Now().Add(-2 * window)
+				a.turnInFlight = true
+			},
+			want: false,
+		},
+		{
+			name:   "disabled by config",
+			mutate: func(c *config.Config) { c.AutoSwapIdleAfterSeconds = 0 },
+			prepare: func(a *activity) {
+				a.lastAt = time.Now().Add(-2 * window)
+			},
+			want: false,
+		},
+		{
+			// Restarting without --resume would silently drop the user's
+			// conversation. Not a trade cux may make on its own initiative.
+			name:   "auto_resume off",
+			mutate: func(c *config.Config) { c.AutoResume = false },
+			prepare: func(a *activity) {
+				a.lastAt = time.Now().Add(-2 * window)
+			},
+			want: false,
+		},
+		{
+			name:   "threshold switching off entirely",
+			mutate: func(c *config.Config) { c.AutoSwitchOnThreshold = false },
+			prepare: func(a *activity) {
+				a.lastAt = time.Now().Add(-2 * window)
+			},
+			want: false,
+		},
+		{
+			// Another branch of step already queued a swap; do not stack.
+			name: "a swap is already pending",
+			prepare: func(a *activity) {
+				a.lastAt = time.Now().Add(-2 * window)
+			},
+			swap: &pending{reason: "already queued"},
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := idleTestConfig()
+			if c.mutate != nil {
+				c.mutate(cfg)
+			}
+			act := newActivity(time.Now())
+			act.nextCheck = time.Now().Add(-time.Second) // throttle already elapsed
+			if c.prepare != nil {
+				c.prepare(act)
+			}
+			var mu sync.Mutex
+			swap := c.swap
+			if got := idleSwapDue(cfg, act, &mu, &swap); got != c.want {
+				t.Errorf("idleSwapDue = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// The signal poll runs every 100ms; the idle evaluation must not.
+func TestIdleSwapDueThrottles(t *testing.T) {
+	cfg := idleTestConfig()
+	act := newActivity(time.Now().Add(-2 * time.Hour))
+	act.nextCheck = time.Now().Add(-time.Second)
+	var mu sync.Mutex
+	var swap *pending
+
+	if !idleSwapDue(cfg, act, &mu, &swap) {
+		t.Fatal("first check should be due")
+	}
+	if idleSwapDue(cfg, act, &mu, &swap) {
+		t.Error("second check immediately after must be throttled")
+	}
+	if act.nextCheck.Before(time.Now().Add(idleCheckInterval / 2)) {
+		t.Errorf("nextCheck = %v, want ~%v out", act.nextCheck, idleCheckInterval)
+	}
+}
+
+// A check that did no work must not consume the once-a-minute slot, or a
+// turn ending mid-window would push the real evaluation a minute further
+// out for no reason.
+func TestIdleSwapDueDoesNotBurnTheThrottleOnChecksThatDidNothing(t *testing.T) {
+	cfg := idleTestConfig()
+	var mu sync.Mutex
+	var swap *pending
+
+	// Long turn in flight, idle clock well past the window.
+	act := newActivity(time.Now().Add(-2 * time.Hour))
+	act.nextCheck = time.Now().Add(-time.Second)
+	before := act.nextCheck
+	act.turnInFlight = true
+
+	if idleSwapDue(cfg, act, &mu, &swap) {
+		t.Fatal("a turn in flight must not be due")
+	}
+	if !act.nextCheck.Equal(before) {
+		t.Error("a mid-turn check must not advance the throttle")
+	}
+
+	// The turn ends. The very next tick should be able to act, not wait
+	// out a slot the mid-turn checks consumed.
+	act.turnInFlight = false
+	if !idleSwapDue(cfg, act, &mu, &swap) {
+		t.Error("should be due immediately once the turn ends")
+	}
+	if !act.nextCheck.After(before) {
+		t.Error("the check that did the work should advance the throttle")
+	}
+}
+
+// Coalescing is the only thing between this path and one usage poll per
+// idle terminal per check, which is the endpoint pressure in #39.
+func TestIdleRefreshCoalesceCoversTheCheckInterval(t *testing.T) {
+	if idleRefreshCoalesce < idleCheckInterval {
+		t.Errorf("idleRefreshCoalesce (%v) must be >= idleCheckInterval (%v)",
+			idleRefreshCoalesce, idleCheckInterval)
+	}
+}
+
+func TestDefaultIdleWindowIsFifteenMinutes(t *testing.T) {
+	if got := config.Defaults().AutoSwapIdleAfterSeconds; got != 900 {
+		t.Errorf("default auto_swap_idle_after_seconds = %d, want 900", got)
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -522,6 +522,7 @@ func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config,
 	)
 	var stopRequested atomic.Bool
 	var hadTurns atomic.Bool // true once the first Stop signal fires
+	act := newActivity(time.Now())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -536,7 +537,7 @@ func launch(claudeBin string, argv []string, wrapperPID int, cfg *config.Config,
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				step(wrapperPID, cfg, manualTarget, &mu, &sessionID, &swap, &stopRequested, &hadTurns, ch, w)
+				step(wrapperPID, cfg, manualTarget, &mu, &sessionID, &swap, &stopRequested, &hadTurns, act, ch, w)
 			}
 		}
 	}()
@@ -585,6 +586,7 @@ func step(
 	swap **pending,
 	stopRequested *atomic.Bool,
 	hadTurns *atomic.Bool,
+	act *activity,
 	ch child,
 	w io.Writer,
 ) {
@@ -682,6 +684,22 @@ func step(
 		}
 	}
 
+	// 3b. Prompt submitted: the user is at the keyboard. Resets the idle
+	//     clock, and marks a turn in flight when the prompt actually
+	//     reached the model.
+	if b, ok, _ := signals.Read(wrapperPID, signals.PromptSubmitted); ok {
+		_ = signals.Consume(wrapperPID, signals.PromptSubmitted)
+		p, _ := signals.DecodePromptSubmitted(b)
+		mu.Lock()
+		act.lastAt = time.Now()
+		act.turnInFlight = p.StartsTurn
+		mu.Unlock()
+		// Registry heartbeat. Before this, updatedAt only moved on a swap,
+		// so `cux sessions` reported "running" identically for a session
+		// working and one untouched for six days (#39).
+		registry.UpdateSelf(func(e *registry.Entry) {})
+	}
+
 	// 4. Stop signal: a turn just ended cleanly.
 	//
 	// Order matters here. We refresh the active account's usage
@@ -698,6 +716,11 @@ func step(
 			*sessionID = p.SessionID
 			mu.Unlock()
 		}
+		mu.Lock()
+		act.lastAt = time.Now()
+		act.turnInFlight = false
+		mu.Unlock()
+		registry.UpdateSelf(func(e *registry.Entry) {})
 		if email, err := switcher.CurrentLiveEmail(); err == nil {
 			_ = monitor.RefreshActive(email)
 		}
@@ -714,6 +737,77 @@ func step(
 			return
 		}
 	}
+
+	// 5. Idle migration: nobody is here, and this session is sitting on an
+	//    account that is over threshold.
+	//
+	//    Both trigger paths above need an event from this session — a
+	//    prompt, or a turn ending. A terminal left at an empty prompt
+	//    produces neither, so its seat stayed frozen wherever it was at
+	//    launch, however far past the threshold that seat drifted
+	//    afterwards (#39). Moving it while nobody is waiting is also
+	//    strictly cheaper than moving it on the prompt that starts real
+	//    work, which is when it used to happen.
+	if idleSwapDue(cfg, act, mu, swap) {
+		// Coalesced across processes: with many idle terminals this must
+		// not become one usage poll per terminal per check. Errors are
+		// dropped on purpose — including a lock timeout under contention.
+		// A missed idle migration costs nothing: the next tick retries, and
+		// the turn-end path still catches this seat the moment anyone uses
+		// the session.
+		_, _ = monitor.RefreshAllCoalesced(idleRefreshCoalesce)
+		mu.Lock()
+		if *swap == nil {
+			if p := evaluateThresholdSwap(cfg, manualTarget); p != nil {
+				p.reason += " while idle"
+				*swap = p
+			}
+		}
+		hasSwap := *swap != nil
+		mu.Unlock()
+		if hasSwap && stopRequested.CompareAndSwap(false, true) {
+			fmt.Fprintf(w, "\ncux: idle on an account over threshold — migrating now rather than when you come back\n")
+			go gracefulExit(ch, w)
+			return
+		}
+	}
+}
+
+// idleSwapDue reports whether this tick should evaluate an idle migration,
+// advancing the throttle when it does.
+//
+// Requires auto_resume. A rate-limit swap has to restart the session
+// whatever the cost, but this one is cux's own initiative against a
+// session the user has not touched — and relaunching without --resume
+// would silently discard their conversation. Off means no idle migration.
+func idleSwapDue(cfg *config.Config, act *activity, mu *sync.Mutex, swap **pending) bool {
+	if cfg.AutoSwapIdleAfterSeconds <= 0 || !cfg.AutoSwitchOnThreshold || !cfg.AutoResume {
+		return false
+	}
+	now := time.Now()
+	mu.Lock()
+	defer mu.Unlock()
+	if *swap != nil {
+		return false
+	}
+	// Cheap checks first, and the throttle last: everything above this is
+	// an in-memory compare that costs nothing at the 100 ms poll rate, so
+	// only the tick that is actually going to refresh usage and evaluate a
+	// swap should consume the once-a-minute slot. Advancing earlier would
+	// let a check that did no work — a session mid-turn, or one not yet
+	// past its window — push the real evaluation a minute further out.
+	idle, ok := act.idleFor(now)
+	if !ok {
+		return false
+	}
+	if idle < time.Duration(cfg.AutoSwapIdleAfterSeconds)*time.Second {
+		return false
+	}
+	if now.Before(act.nextCheck) {
+		return false
+	}
+	act.nextCheck = now.Add(idleCheckInterval)
+	return true
 }
 
 // snapshotActiveUsage returns whatever the cache currently has for the
@@ -909,7 +1003,60 @@ const (
 	// well under waitPollInterval so no freshness-sensitive caller could
 	// ever be starved of a current reading by coalescing.
 	refreshCoalesceWindow = 20 * time.Second
+
+	// idleCheckInterval is how often an otherwise-quiet wrapper evaluates
+	// itself for idle migration. The signal poll runs every 100 ms; this
+	// throttle is what keeps a feature that only matters on the scale of
+	// minutes from doing anything at that cadence.
+	idleCheckInterval = time.Minute
+	// idleRefreshCoalesce must be >= idleCheckInterval. This is the only
+	// path that adds a network call to a wrapper with nothing happening,
+	// so the window is what stops N idle terminals from becoming N usage
+	// polls a minute — the endpoint 429s that #39 was partly filed for.
+	// Larger than the check interval means a terminal cannot trigger more
+	// than one sweep per window no matter how the ticks line up.
+	idleRefreshCoalesce = 2 * time.Minute
 )
+
+// activity is the wrapper's model of whether a human is present, kept for
+// the lifetime of one claude launch.
+//
+// The wrapper sees only hook signals, and until #39 none of them said "the
+// user typed something" — so a session parked at an empty prompt and one
+// twenty minutes into a turn looked identical. Both would have been
+// migrated by an idle check reading time-since-last-Stop, and restarting
+// the second kills live work.
+//
+// Owned by the single poll goroutine. The mutex taken around reads and
+// writes below is the one that already guards `swap` in the same critical
+// sections — it is not making `activity` safe for a second reader, and
+// anyone adding one should not assume it does.
+type activity struct {
+	lastAt time.Time
+	// turnInFlight vetoes migration outright. It is set by a prompt that
+	// goes to the model and cleared by the Stop that ends it. If a turn
+	// dies without a Stop it stays set and this session simply never
+	// migrates: the safe direction, and the next completed turn clears it.
+	turnInFlight bool
+	nextCheck    time.Time
+}
+
+func newActivity(now time.Time) *activity {
+	// Launch counts as activity, so a fresh terminal gets the full idle
+	// window before it can be moved. A wrapper started and never touched
+	// becomes eligible one window later, which is the case in #39: those
+	// terminals were pinned to a capped seat from launch.
+	return &activity{lastAt: now, nextCheck: now.Add(idleCheckInterval)}
+}
+
+// idleFor reports how long the session has been without a prompt or a
+// completed turn. A turn in flight is never idle, whatever the clock says.
+func (a *activity) idleFor(now time.Time) (time.Duration, bool) {
+	if a.turnInFlight {
+		return 0, false
+	}
+	return now.Sub(a.lastAt), true
+}
 
 func waitForReset(trigger history.Trigger, cfg *config.Config, w io.Writer) (string, error) {
 	for {


### PR DESCRIPTION
Addresses part **(b)** of #39 — the `balanced`-not-redistributing case. The classifier half of that issue shipped in 0.3.5/0.3.6; this is the idle-session pinning the reporter diagnosed in [their follow-up](https://github.com/inulute/cux/issues/39#issuecomment-5187406576).

## The cause

Every threshold trigger needs an event from the session itself — a prompt submitted, or a turn ending. There are exactly three, and all three are session-scoped:

- `handleAutoSwitchPrompt` (prompt-submit hook)
- the turn-end path in `step` (Stop signal → `evaluateThresholdSwap`)
- `evaluatePrelaunchHardLimitSwap` (only on `--resume`, only at hard limit)

A terminal parked at an empty prompt produces none of them, so its seat stays frozen wherever it was at launch, however far past the threshold that seat later drifts. In the report, two terminals sat on an account that crossed 98% of its 7-day window and stayed there six days while four threshold swaps happened around them. The migration then landed on the prompt that started real work — the most expensive moment for it rather than the cheapest.

The reporter's own read was right: not a missing trigger, a missing clock. Both existing paths work when reached.

One correction to their suggested landing spot, since it shaped the fix: `poll_interval_seconds` is dead config — nothing outside `config.go` reads it, and there is no background monitor process to hang idle migration on. So this lives in the wrapper's existing signal poll loop instead: no new process, no new IPC.

## Doing it safely

The wrapper could not tell "parked at an empty prompt" from "twenty minutes into a turn". Hooks reported `session-started` and `stopped`, never "the user typed something", so a long tool call and an abandoned terminal both look like silence — and restarting the first kills live work, which is the damage class from the original report.

- **New `prompt-submitted` signal.** `StartsTurn` is false for a prompt the hook handles itself (`/switch`, `/cux:*`, an intercepted swap): those are blocked and never reach the model, so no `Stop` follows, and marking one as a turn start would leave the session looking busy forever. They still reset the idle clock — whoever typed one is present.
- **`turnInFlight` vetoes migration outright.** A turn that dies without a `Stop` leaves it set and that session simply never migrates: the safe direction, and the next completed turn clears it.
- **Requires `auto_resume`.** A rate-limit swap has to restart the session whatever the cost. This one is cux's own initiative against a session the user has not touched, and relaunching without `--resume` would silently discard their conversation.

## Also

- The registry heartbeat now moves on prompt-submitted and stopped, not only on a swap. `cux sessions` previously reported `running` identically for a session working and one untouched for six days, so nothing could distinguish idle from busy — the reporter's consequence (2).
- The idle evaluation is throttled to once a minute against a 100 ms signal poll, and its usage refresh is coalesced over a window longer than the check interval, so N idle terminals cannot become N usage polls a minute. Cheap in-memory checks run before the throttle so a tick that does no work does not consume the slot.

Default `auto_swap_idle_after_seconds: 900` — long enough that reading output or thinking between prompts is never mistaken for absence, short enough that a terminal left overnight moves during the quiet hours. `0` disables it.

## Verification

Tests cover the gates rather than the plumbing: a turn in flight is never idle however long it runs; `auto_resume` off, a pending swap, and the master toggle each suppress migration; the throttle holds and is not consumed by checks that did no work; the coalesce window covers the check interval; and the hook reports `StartsTurn` correctly for a model prompt, a hook-handled prompt, and an unwrapped session. Removing the turn-in-flight veto fails two of them.

**Not verified:** the concurrency behaviour of many wrappers contending for the usage lock on a one-minute tick. `RefreshAllCoalesced` takes the cross-process lock, and while coalescing means all but one skip the *fetch*, they still queue for the *lock* on a schedule they did not have before. That needs a multi-terminal box. Deliberately not released to npm for this reason — `latest` stays 0.3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
